### PR TITLE
Added new property to old gui templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,6 +96,7 @@ perun_oldgui_cert_hosts:
 perun_oldgui_logoUrl: 'img/logo.png'
 perun_oldgui_nativeLanguage: 'cs,\u010Cesky,Czech'
 perun_oldgui_language_supported: 'cs'
+perun_oldgui_registrar_findSimilarUsers_disabled: 'false'
 perun_oldgui_profile_personal_showAttributes:
   - urn:perun:user:attribute-def:core:displayName
   - urn:perun:user:attribute-def:def:organization

--- a/templates/perun-web-gui.properties.j2
+++ b/templates/perun-web-gui.properties.j2
@@ -111,6 +111,10 @@ registrar.enforceProxy={{ perun_oldgui_registrar_enforceProxy }}
 # format: "vo_short_name" or "vo_short_name:group_name".
 #registrar.skipSummaryFor=
 
+# When set to true, finding of similar users after clicking on the registration submit button will not be triggered.
+# Therefore, account linking will not be offered to users even when they already have registered some similar accounts.
+registrar.findSimilarUsers.disabled={{ perun_oldgui_registrar_findSimilarUsers_disabled }}
+
 ### User Profile ###
 
 # defines urn of user attributes that should be displayed on personal page


### PR DESCRIPTION
- New property registrar.findSimilarUsers.disabled was added to the
  perun-web-gui template. Default value (false) was set to the default main file.