### PR TITLE
perun_rpc_sendIdentityAlerts added to template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,7 @@ perun_rpc_attributesToKeep:
   - urn:perun:user:attribute-def:def:login-namespace:*
   - urn:perun:user:attribute-def:def:uid-namespace:*
 perun_rpc_ajp_secret: "xpRrA7UNrT7c"
+perun_rpc_sendIdentityAlerts: 'false'
 
 # old GUI
 perun_oldgui_defaultRtQueue: "perun"

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -152,3 +152,6 @@ perun.attributesToAnonymize={{ perun_rpc_attributesToAnonymize|join(',') }}
 
 # List of user attributes URNs that should be kept without change during user's anonymization
 perun.attributesToKeep={{ perun_rpc_attributesToKeep|join(',') }}
+
+# When set to true, notifications about account linking are send to afffected user 
+perun.sendIdentityAlerts={{ perun_rpc_sendIdentityAlerts }}


### PR DESCRIPTION
- This option will be used to enable notifications which will be send
  when someone links accounts through the Consolidator. Default value is
  false.