### PR TITLE
Shibboleth sessions set consistentAddress

### DIFF
--- a/templates/shibboleth2.xml.j2
+++ b/templates/shibboleth2.xml.j2
@@ -28,7 +28,7 @@
         cookieProps to "https" for SSL-only sites. Note that while we default checkAddress to
         "false", this makes an assertion stolen in transit easier for attackers to misuse.
         -->
-        <Sessions lifetime="28800" timeout="3600" relayState="ss:mem" checkAddress="false" handlerSSL="true" cookieProps="https">
+        <Sessions lifetime="28800" timeout="3600" relayState="ss:mem" checkAddress="false" consistentAddress="false" handlerSSL="true" cookieProps="https">
 
             <!--
             Configures SSO for a default IdP. To properly allow for >1 IdP, remove


### PR DESCRIPTION
- consistentAddress set to "false" so the session does not depend on IP address.