### PR TITLE
New rpc property findSimilarUsersDisabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,6 +82,7 @@ perun_rpc_attributesToKeep:
   - urn:perun:user:attribute-def:def:uid-namespace:*
 perun_rpc_ajp_secret: "xpRrA7UNrT7c"
 perun_rpc_sendIdentityAlerts: 'false'
+perun_rpc_registrar_findSimilarUsers_disabled: 'false'
 
 # old GUI
 perun_oldgui_defaultRtQueue: "perun"
@@ -102,7 +103,7 @@ perun_oldgui_cert_hosts:
 perun_oldgui_logoUrl: 'img/logo.png'
 perun_oldgui_nativeLanguage: 'cs,\u010Cesky,Czech'
 perun_oldgui_language_supported: 'cs'
-perun_oldgui_registrar_findSimilarUsers_disabled: 'false'
+perun_oldgui_registrar_findSimilarUsers_disabled: '{{ perun_rpc_registrar_findSimilarUsers_disabled }}'
 perun_oldgui_profile_personal_showAttributes:
   - urn:perun:user:attribute-def:core:displayName
   - urn:perun:user:attribute-def:def:organization

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -157,3 +157,7 @@ perun.attributesToKeep={{ perun_rpc_attributesToKeep|join(',') }}
 
 # When set to true, notifications about account linking are send to afffected user 
 perun.sendIdentityAlerts={{ perun_rpc_sendIdentityAlerts }}
+
+# When set to true, finding of similar users will not be triggered during registrar initialization.
+# Therefore, account linking will not be offered to users even when they already have registered some similar accounts.
+perun.findSimilarUsersDisabled={{ perun_rpc_registrar_findSimilarUsers_disabled }}


### PR DESCRIPTION
- We needed to have an option to disable account linking also on
  backend. Therefore, new property was added. The GUI property has the rpc
  value set by default.