### PR TITLE
Fix indent for restart rpc

### DIFF
--- a/tasks/perun_rpc.yml
+++ b/tasks/perun_rpc.yml
@@ -32,7 +32,7 @@
     owner: perunrpc
     group: perunrpc
     mode: '0440'
-    notify: "restart perun_rpc"
+  notify: "restart perun_rpc"
 
 - name: "create perun-web-gui.properties"
   template:


### PR DESCRIPTION
- during reloading perun-roles.yml notify module had wrong indendation.