### PR TITLE
feat: added new rpc property lookupUserByIdentifiersAndExtSouceLogin

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,7 @@ perun_rpc_alternativePasswordManager_program: ""
 perun_rpc_native_language: 'cs,Česky,Czech'
 perun_rpc_userExtSources_persistent: "PERUN;"
 perun_rpc_extsources_multiple_identifiers: ""
+perun_rpc_lookup_user_by_identifiers_and_extSourceLogin: 'false'
 perun_rpc_defaultLoa_idp: "2"
 perun_rpc_recaptcha_privatekey: '6Lf0eUYUAAAAAIBxpRrA7UNrT7czQ28IoH9yiDBE'
 perun_rpc_mailchange_secretKey: "test"

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -136,6 +136,9 @@ perun.autocreatedNamespaces=
 # Name of ExtSources with support for multiple identifiers
 perun.extsources.multiple.identifiers={{ perun_rpc_extsources_multiple_identifiers }}
 
+# Try to lookup user by additional identifiers and if it is null, then lookup by user ext source name and login
+perun.lookup.user.by.identifiers.and.extSourceLogin={{ perun_rpc_lookup_user_by_identifiers_and_extSourceLogin }}
+
 perun.defaultLoa.idp={{ perun_rpc_defaultLoa_idp }}
 
 {% if perun_rpc_group_nameSecondaryRegex is defined %}


### PR DESCRIPTION
* This property allows to try to lookup user by additional identifiers and if no user has been
found, then perun tries to lookup user also by ext source name and login. Default value is false.