### PR TITLE
Create empty entries for disabled apps in perun-apps-config.yml

### DIFF
--- a/templates/perun-apps-config.yml.j2
+++ b/templates/perun-apps-config.yml.j2
@@ -7,21 +7,33 @@ brands:
       api: "https://{{ perun_api_hostname }}"
 {% if perun_ngui_admin_enabled %}
       admin: "https://{{ perun_ngui_admin_hostname }}"
+{% else %}
+      admin: ""
 {% endif %}
 {% if perun_ngui_profile_enabled %}
       profile: "https://{{ perun_ngui_profile_hostname }}"
+{% else %}
+      profile: ""
 {% endif %}
 {% if perun_ngui_pwdreset_enabled %}
       pwd_reset: "https://{{ perun_ngui_pwdreset_hostname }}"
+{% else %}
+      pwd_reset: ""
 {% endif %}
 {% if perun_ngui_publications_enabled %}
       publications: "https://{{ perun_ngui_publications_hostname }}"
+{% else %}
+      publications: ""
 {% endif %}
 {% if perun_ngui_consolidator_enabled %}
       consolidator: "https://{{ perun_ngui_consolidator_hostname }}"
+{% else %}
+      consolidator: ""
 {% endif %}
 {% if perun_ngui_linker_enabled %}
       linker: "https://{{ perun_ngui_linker_hostname }}"
+{% else %}
+      linker: ""
 {% endif %}
     old_gui_domain: "https://{{ perun_rpc_hostname }}"
 {% for item in perun_rpc_hostname_aliases %}


### PR DESCRIPTION
- Internal logic required entries for apps locations to be
  present and set to empty string even if app is not used.