### PR TITLE
Allow setting custom api_url in instanceConfig.json

### DIFF
--- a/templates/instance_configs/consolidatorInstanceConfig.json.j2
+++ b/templates/instance_configs/consolidatorInstanceConfig.json.j2
@@ -1,6 +1,10 @@
 {
   "config": "{{ perun_ngui_consolidator_hostname }}",
+{% if perun_ngui_consolidator_api_url is defined %}
+  "api_url": "https://{{ perun_ngui_consolidator_api_url }}/oauth/rpc",
+{% else %}
   "api_url": "https://{{ perun_api_hostname }}/oauth/rpc",
+{% endif %}
   "oidc_client" : {
       "oauth_authority": "{{ perun_ngui_consolidator_oauth_authority }}",
       "oauth_callback": "{{ perun_ngui_consolidator_oauth_callback }}",

--- a/templates/instance_configs/instanceConfig.json.j2
+++ b/templates/instance_configs/instanceConfig.json.j2
@@ -1,6 +1,10 @@
 {
   "config": "admin {{ perun_ngui_admin_hostname }}",
+{% if perun_ngui_admin_api_url is defined %}
+  "api_url": "https://{{ perun_ngui_admin_api_url }}/oauth/rpc",
+{% else %}
   "api_url": "https://{{ perun_api_hostname }}/oauth/rpc",
+{% endif %}
   "document_title": "{{ perun_ngui_admin_document_title }}",
   "instance_favicon": {{ perun_ngui_admin_instance_favicon|to_json }},
 {% if perun_ngui_admin_warning_message %}

--- a/templates/instance_configs/linkerInstanceConfig.json.j2
+++ b/templates/instance_configs/linkerInstanceConfig.json.j2
@@ -1,6 +1,10 @@
 {
   "config": "{{ perun_ngui_linker_hostname }}",
+{% if perun_ngui_linker_api_url is defined %}
+  "api_url": "https://{{ perun_ngui_linker_api_url }}/oauth/rpc",
+{% else %}
   "api_url": "https://{{ perun_api_hostname }}/oauth/rpc",
+{% endif %}
   "oidc_client" : {
       "oauth_authority": "{{ perun_ngui_linker_oauth_authority }}",
       "oauth_callback": "{{ perun_ngui_linker_oauth_callback }}",

--- a/templates/instance_configs/profileInstanceConfig.json.j2
+++ b/templates/instance_configs/profileInstanceConfig.json.j2
@@ -1,7 +1,11 @@
 {
   "document_title": {{ perun_ngui_profile_document_title|to_json }},
   "instance_favicon": {{ perun_ngui_profile_instance_favicon|to_json }},
+{% if perun_ngui_profile_api_url is defined %}
+  "api_url": "https://{{ perun_ngui_profile_api_url }}/oauth/rpc",
+{% else %}
   "api_url": "https://{{ perun_api_hostname }}/oauth/rpc",
+{% endif %}
   "auto_auth_redirect": {{ perun_ngui_profile_auto_oauth_redirect|to_json }},
   "supported_languages": {{ perun_ngui_profile_supported_languages|to_nice_json }},
   "oidc_client" : {

--- a/templates/sites-enabled/perun-admin.conf.j2
+++ b/templates/sites-enabled/perun-admin.conf.j2
@@ -88,7 +88,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_oauth_authority }} https://{{ perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_oauth_authority }} https://{{ perun_ngui_admin_api_url if perun_ngui_admin_api_url is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-consolidator.conf.j2
+++ b/templates/sites-enabled/perun-consolidator.conf.j2
@@ -79,7 +79,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_consolidator_oauth_authority }} https://{{ perun_api_hostname }}; img-src 'self' data: https: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_consolidator_oauth_authority }} https://{{ perun_ngui_consolidator_api_url if perun_ngui_consolidator_api_url is defined else perun_api_hostname }}; img-src 'self' data: https: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-linker.conf.j2
+++ b/templates/sites-enabled/perun-linker.conf.j2
@@ -78,7 +78,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_linker_oauth_authority }} https://{{ perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_linker_oauth_authority }} https://{{ perun_ngui_linker_api_url if perun_ngui_linker_api_url is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-profile.conf.j2
+++ b/templates/sites-enabled/perun-profile.conf.j2
@@ -83,7 +83,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_profile_oauth_authority }} https://{{ perun_api_hostname }} {{ perun_ngui_profile_mfa.api_url if perun_ngui_profile_mfa.api_url is defined else '' }} ; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_profile_oauth_authority }} https://{{ perun_ngui_profile_api_url if perun_ngui_profile_api_url is defined else perun_api_hostname }} {{ perun_ngui_profile_mfa.api_url if perun_ngui_profile_mfa.api_url is defined else '' }} ; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/


### PR DESCRIPTION
- In cases of migration of proxy endpoints we must be able to set
  custom API URL for each application (different from perun_api_hostname,
  or perun_rpc_hostname).
- Also overide CSP settings in Apache config for each app.