### PR TITLE
Make host certificates available to rpc container

### DIFF
--- a/files/perun_posthook.sh
+++ b/files/perun_posthook.sh
@@ -7,6 +7,9 @@ systemctl restart slapd
 cp /etc/perun/ssl/hostcert.pem /etc/perun/engine/ssl/perun-send.pem
 cp /etc/perun/ssl/hostkey.pem /etc/perun/engine/ssl/perun-send.key
 cp /etc/perun/ssl/hostchain.pem /etc/perun/engine/ssl/perun-send.chain
+cp /etc/perun/ssl/hostcert.pem /etc/perun/rpc/ssl/perun-host.pem
+cp /etc/perun/ssl/hostkey.pem /etc/perun/rpc/ssl/perun-host.key
+cp /etc/perun/ssl/hostchain.pem /etc/perun/rpc/ssl/perun-host.chain
 docker start perun_rpc
 docker start perun_engine
 docker start perun_ldapc

--- a/tasks/perun_rpc.yml
+++ b/tasks/perun_rpc.yml
@@ -137,6 +137,29 @@
     - "files/{{ perun_instance_hostname }}/modules/*"
   notify: "restart perun_rpc"
 
+- name: "make key, cert and chain for purpose of password managers in rpc"
+  block:
+    - name: "create rpc ssl dir"
+      file:
+        state: directory
+        path: /etc/perun/rpc/ssl
+        owner: root
+        group: perunrpc
+        mode: '0550'
+
+    - name: "copy host certificates for pwd managers in rpc"
+      copy:
+        remote_src: yes
+        src: "/etc/perun/ssl/{{ item.src }}"
+        dest: "/etc/perun/rpc/ssl/{{ item.dest }}"
+        owner: root
+        group: perunrpc
+        mode: '0550'
+      loop:
+        - { src: "hostkey.pem", dest: "perun-host.key" }
+        - { src: "hostcert.pem", dest: "perun-host.pem" }
+        - { src: "hostchain.pem", dest: "perun-host.chain" }
+
 - name: "detect local directory perun_rpc_etc/"
   local_action:
     module: stat


### PR DESCRIPTION
- Make sure host certificates are avaialble in perun-rpc container in /etc/perun/ssl/ for the purpose of password managers.
- Ensure certs are copied when re-newed in perun_posthook.