### PR TITLE
Support custom CSP url for new GUI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -163,6 +163,7 @@ perun_roles_management: {}
 # new GUI common
 perun_ngui_admin_enabled: false
 perun_ngui_oauth_authority: "{{ perun_rpc_oidc_issuers[0].iss }}"
+perun_ngui_oauth_csp_url: "{{ perun_ngui_oauth_authority }}"
 perun_ngui_oauth_offline_access_consent_prompt: true
 perun_ngui_footer:
   columns:
@@ -246,6 +247,7 @@ perun_ngui_profile_tls_cert_same_as_host: yes
 perun_ngui_profile_instance_favicon: false
 perun_ngui_profile_auto_oauth_redirect: true
 perun_ngui_profile_oauth_authority: '{{ perun_ngui_oauth_authority }}'
+perun_ngui_profile_oauth_csp_url: '{{ perun_ngui_profile_oauth_authority }}'
 perun_ngui_profile_csp_connect_src: ''
 perun_ngui_profile_oauth_callback: "https://{{ perun_ngui_profile_hostname }}/api-callback"
 perun_ngui_profile_client_id: "xxx-xxxx-xxxx-xxx-xx-xxx"
@@ -321,6 +323,7 @@ perun_ngui_consolidator_tls_cert_same_as_host: yes
 perun_ngui_consolidator_document_title: "Consolidator"
 perun_ngui_consolidator_client_id: "xxx-xxxx-xxxx-xxx-xx-xxx"
 perun_ngui_consolidator_oauth_authority: '{{ perun_ngui_oauth_authority }}'
+perun_ngui_consolidator_oauth_csp_url: '{{ perun_ngui_consolidator_oauth_authority }}'
 perun_ngui_consolidator_oauth_callback: "https://{{ perun_ngui_consolidator_hostname }}/api-callback"
 perun_ngui_consolidator_oauth_redirect_uri: "https://{{ perun_ngui_consolidator_hostname }}/api-callback"
 perun_ngui_consolidator_oauth_load_user_info: true
@@ -343,6 +346,7 @@ perun_ngui_linker_tls_cert_same_as_host: yes
 perun_ngui_linker_document_title: "Linker"
 perun_ngui_linker_client_id: "xxx-xxxx-xxxx-xxx-xx-xxx"
 perun_ngui_linker_oauth_authority: '{{ perun_ngui_oauth_authority }}'
+perun_ngui_linker_oauth_csp_url: '{{ perun_ngui_linker_oauth_authority }}'
 perun_ngui_linker_oauth_callback: "https://{{ perun_ngui_linker_hostname }}/api-callback"
 perun_ngui_linker_oauth_redirect_uri: "https://{{ perun_ngui_linker_hostname }}/api-callback"
 perun_ngui_linker_oauth_load_user_info: true

--- a/templates/sites-enabled/perun-admin.conf.j2
+++ b/templates/sites-enabled/perun-admin.conf.j2
@@ -88,7 +88,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_oauth_authority }} https://{{ perun_ngui_admin_api_url if perun_ngui_admin_api_url is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_oauth_csp_url }} https://{{ perun_ngui_admin_api_url if perun_ngui_admin_api_url is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-consolidator.conf.j2
+++ b/templates/sites-enabled/perun-consolidator.conf.j2
@@ -79,7 +79,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_consolidator_oauth_authority }} https://{{ perun_ngui_consolidator_api_url if perun_ngui_consolidator_api_url is defined else perun_api_hostname }}; img-src 'self' data: https: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_consolidator_oauth_csp_url }} https://{{ perun_ngui_consolidator_api_url if perun_ngui_consolidator_api_url is defined else perun_api_hostname }}; img-src 'self' data: https: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-linker.conf.j2
+++ b/templates/sites-enabled/perun-linker.conf.j2
@@ -78,7 +78,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_linker_oauth_authority }} https://{{ perun_ngui_linker_api_url if perun_ngui_linker_api_url is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_linker_oauth_csp_url }} https://{{ perun_ngui_linker_api_url if perun_ngui_linker_api_url is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-profile.conf.j2
+++ b/templates/sites-enabled/perun-profile.conf.j2
@@ -83,7 +83,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_profile_oauth_authority }} https://{{ perun_ngui_profile_api_url if perun_ngui_profile_api_url is defined else perun_api_hostname }} {{ perun_ngui_profile_mfa.api_url if perun_ngui_profile_mfa.api_url is defined else '' }} ; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_profile_oauth_csp_url }} https://{{ perun_ngui_profile_api_url if perun_ngui_profile_api_url is defined else perun_api_hostname }} {{ perun_ngui_profile_mfa.api_url if perun_ngui_profile_mfa.api_url is defined else '' }} ; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/


### PR DESCRIPTION
- In EGI infrastructure proxy (OIDC issuer) doesn't end with "/", but CSP rules with path require value ending with a slash.
- Added new property "perun_ngui_oauth_csp_url" in order to allow overriding of default value from "perun_ngui_oauth_authority". Similar variables added for other new GUI apps.