### PR TITLE
Allow setting more properties of new Admin GUI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -221,6 +221,8 @@ perun_ngui_admin_hostname: "perun.aai.example.org"
 perun_ngui_admin_hostname_aliases: []
 perun_ngui_admin_tls_cert_same_as_host: yes
 perun_ngui_admin_document_title: "Perun Next Generation Web UI"
+perun_ngui_admin_auto_oauth_redirect: true
+perun_ngui_admin_auto_service_access_redirect: false
 perun_ngui_admin_client_id: "xxx-xxxx-xxxx-xxx-xx-xxx"
 perun_ngui_admin_oauth_callback: "https://{{ perun_ngui_admin_hostname }}/api-callback"
 perun_ngui_admin_oauth_post_logout_redirect_uri: "https://{{ perun_ngui_admin_hostname }}/api-callback"

--- a/templates/instance_configs/instanceConfig.json.j2
+++ b/templates/instance_configs/instanceConfig.json.j2
@@ -13,6 +13,8 @@
   "warning_message": "{{ perun_ngui_admin_warning_message }}",
 {% endif %}
   "is_devel": {{ perun_oldgui_isDevel|bool|to_json }},
+  "auto_auth_redirect": {{ perun_ngui_admin_auto_oauth_redirect|to_json }},
+  "auto_service_access_redirect": {{ perun_ngui_admin_auto_service_access_redirect|to_json }},
   "oidc_client" : {
     "oauth_authority": "{{ perun_ngui_oauth_authority }}",
     "oauth_callback": "{{ perun_ngui_admin_oauth_callback }}",


### PR DESCRIPTION
- Allow to set auto_oath_redirect and auto_service_access_redirect for the admin GUI defaulting to same values as in defaultConfig.json.
- It will be used in the future for the CESNET and VSUP instances.