### PR TITLE
Use proper API domains for CLI and Engine

### DIFF
--- a/templates/perun-cli-env.j2
+++ b/templates/perun-cli-env.j2
@@ -4,7 +4,13 @@
 # and https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file
 
 # Perun agent variables
+{% if perun_api_enabled %}
 PERUN_URL=https://{{ perun_api_hostname }}/ba/rpc/
+{% elif perun_api_alternative_enabled %}
+PERUN_URL=https://{{ perun_api_alternative_hostname }}/ba/rpc/
+{% else %}
+PERUN_URL=https://{{ perun_api_hostname }}/ba/rpc/
+{% endif %}
 PERUN_USER=perun/{{ perun_apache_basicAuth_user_perun_password }}
 PERUN_COOKIE=/tmp/perun-cli-cookie.txt
 PERL5LIB=/opt/perun-cli/:/opt/perun-cli/Perun/

--- a/templates/perun-engine.j2
+++ b/templates/perun-engine.j2
@@ -2,6 +2,12 @@
 
 # Allow perun-engine to call Perun
 export PERUN_USER=perun-engine/{{ perun_apache_basicAuth_common['perun-engine'] }}
+{% if perun_api_enabled %}
 export PERUN_URL=https://{{ perun_api_hostname }}/ba/rpc/
+{% elif perun_api_alternative_enabled %}
+export PERUN_URL=https://{{ perun_api_alternative_hostname }}/ba/rpc/
+{% else %}
+export PERUN_URL=https://{{ perun_api_hostname }}/ba/rpc/
+{% endif %}
 export PERUN_COOKIE=/tmp/.perun-engine-cookie.txt
 export PERL5LIB=/opt/perun-engine/lib/:.


### PR DESCRIPTION
- We can use either API domain or alternative API domain. Current config causes problems to instances with only alternative API domains.
- New config prefers API domain if it is enabled (expected to be different from rpc hostname). If not, then we use alternative API domain, if it is again enabled. If there are no specific api configs, we default to API domain which should be rpc hostname.