### PR TITLE
Use proper API domains for CLI and Engine

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -383,6 +383,9 @@ perun_apache_oauth_alternative_introspection_url: https://other.oidc.provider/oi
 perun_apache_oauth_alternative_client_id: "yyyyyyyyy-yyyyyyyyy-yyyyyyyyy-yyyyyyyy"
 perun_apache_oauth_alternative_client_secret: "YYYYYYYYYYYYYYYYY"
 
+# pointers to API for CLI and Engine
+perun_api_for_cli_hostname: "{{ perun_api_hostname }}"
+perun_api_for_engine_hostname: "{{ perun_api_hostname }}"
 
 # perun-registrar-lib.properties
 perun_registrar_secretKey: "test"

--- a/templates/perun-cli-env.j2
+++ b/templates/perun-cli-env.j2
@@ -4,7 +4,7 @@
 # and https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file
 
 # Perun agent variables
-PERUN_URL=https://{{ perun_api_hostname }}/ba/rpc/
+PERUN_URL=https://{{ perun_api_for_cli_hostname }}/ba/rpc/
 PERUN_USER=perun/{{ perun_apache_basicAuth_user_perun_password }}
 PERUN_COOKIE=/tmp/perun-cli-cookie.txt
 PERL5LIB=/opt/perun-cli/:/opt/perun-cli/Perun/

--- a/templates/perun-engine.j2
+++ b/templates/perun-engine.j2
@@ -2,6 +2,6 @@
 
 # Allow perun-engine to call Perun
 export PERUN_USER=perun-engine/{{ perun_apache_basicAuth_common['perun-engine'] }}
-export PERUN_URL=https://{{ perun_api_hostname }}/ba/rpc/
+export PERUN_URL=https://{{ perun_api_for_engine_hostname }}/ba/rpc/
 export PERUN_COOKIE=/tmp/.perun-engine-cookie.txt
 export PERL5LIB=/opt/perun-engine/lib/:.


### PR DESCRIPTION
- Because we use various API domains for Perun we must be able to point CLI and Engine to the right one.
- By default we use "perun_api_hostname", which is by default "perun_rpc_hostname" but each instance can override this value with own config.