### PR TITLE
Removed perun_oldgui_newAdminGuiAlert property

### DIFF
--- a/templates/perun-apps-config.yml.j2
+++ b/templates/perun-apps-config.yml.j2
@@ -36,6 +36,9 @@ brands:
       linker: ""
 {% endif %}
     old_gui_domain: "https://{{ perun_rpc_hostname }}"
+{% if perun_oldgui_alert is defined %}
+    old_gui_alert: {{ perun_oldgui_alert }}
+{% endif %}
 {% for item in perun_rpc_hostname_aliases %}
   - name: {{ item }}
     new_apps:

--- a/templates/perun-web-gui.properties.j2
+++ b/templates/perun-web-gui.properties.j2
@@ -14,9 +14,6 @@ vosToSkipCaptchaFor=
 nativeLanguage={{ perun_oldgui_nativeLanguage }}
 getIdentityConsolidatorUrl={{ perun_oldgui_getIdentityConsolidatorUrl }}
 disableCreateVo={{ perun_oldgui_disableCreateVo }}
-{% if perun_oldgui_newAdminGuiAlert is defined %}
-newAdminGuiAlert={{ perun_oldgui_newAdminGuiAlert }}
-{% endif %}
 # GDPR agreement logic for admins in Perun. Any admin is required to agree with the last version of the text.
 # His approvals are stored in "urn:perun:user:attribute-def:def:gdprAdminApprovedVersions".
 # Relevant to CESNET instance only


### PR DESCRIPTION
- Removed "perun_oldgui_newAdminGuiAlert" property from perun-web-gui.properties file.
- It was replaced with "perun_oldgui_alert" in perun-apps-config.yml.