### PR TITLE
Fix document_title property of admin gui config

### DIFF
--- a/templates/instance_configs/instanceConfig.json.j2
+++ b/templates/instance_configs/instanceConfig.json.j2
@@ -6,7 +6,9 @@
 {% else %}
   "api_url": "https://{{ perun_api_hostname }}/oauth/rpc",
 {% endif %}
-  "document_title": "{{ perun_ngui_admin_document_title }}",
+  "document_title": {
+    "en": "{{ perun_ngui_admin_document_title }}"
+  },
   "instance_favicon": {{ perun_ngui_admin_instance_favicon|to_json }},
 {% if perun_ngui_admin_warning_message %}
   "display_warning": true,


### PR DESCRIPTION
- Property in config actually expect the object with mapping of language to string.
- Not needed for consolidator/linker. Probably needed for pwd reset, but it is not yet supported app in the ansible.