### PR TITLE
Unified naming of ansible properties for perun.properties

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,10 +115,10 @@ perun_rpc_userInfoEndpoint_mfaAuthTimestampPropertyName: ""
 perun_rpc_userInfoEndpoint_mfaAuthTimeout: 24
 perun_rpc_userInfoEndpoint_acrPropertyName: ""
 perun_rpc_userInfoEndpoint_mfaAcrValue: ""
-perun_enforceMfa: 'false'
+perun_rpc_enforceMfa: 'false'
 perun_rpc_mounts_additional: []
-perun_idpLoginValidity: 24
-perun_idpLoginValidityExceptions: []
+perun_rpc_idpLoginValidity: 24
+perun_rpc_idpLoginValidityExceptions: []
 
 # old GUI
 perun_oldgui_defaultRtQueue: "perun"

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -175,7 +175,7 @@ perun.attributesToAnonymize={{ perun_rpc_attributesToAnonymize|join(',') }}
 # List of user attributes URNs that should be kept without change during user's anonymization
 perun.attributesToKeep={{ perun_rpc_attributesToKeep|join(',') }}
 
-# When set to true, notifications about account linking are send to afffected user 
+# When set to true, notifications about account linking are send to afffected user
 perun.sendIdentityAlerts={{ perun_rpc_sendIdentityAlerts }}
 
 # When set to true, finding of similar users will not be triggered during registrar initialization.
@@ -204,10 +204,10 @@ perun.userInfoEndpoint.acrPropertyName={{ perun_rpc_userInfoEndpoint_acrProperty
 perun.userInfoEndpoint.mfaAcrValue={{ perun_rpc_userInfoEndpoint_mfaAcrValue }}
 
 # when set to true, MFA is required for critical operations and attribute actions
-perun.enforceMfa={{ perun_enforceMfa }}
+perun.enforceMfa={{ perun_rpc_enforceMfa }}
 
 # how many months is lastAccess of user IdP extSource valid for attributes retrieval
-perun.idpLoginValidity={{ perun_idpLoginValidity }}
+perun.idpLoginValidity={{ perun_rpc_idpLoginValidity }}
 
 # which virtual attributes should skip lastAccess check of user's IdP extsources
-perun.idpLoginValidityExceptions={{ perun_idpLoginValidityExceptions|join(',') }}
+perun.idpLoginValidityExceptions={{ perun_rpc_idpLoginValidityExceptions|join(',') }}


### PR DESCRIPTION
- Adedd missing _rpc_ into the ansible properties names.