### PR TITLE
Removed perun-notification.proprties

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -119,6 +119,7 @@ perun_rpc_enforceMfa: 'false'
 perun_rpc_mounts_additional: []
 perun_rpc_idpLoginValidity: 24
 perun_rpc_idpLoginValidityExceptions: []
+perun_rpc_notif_send_messages: 'true'
 
 # old GUI
 perun_oldgui_defaultRtQueue: "perun"
@@ -420,11 +421,6 @@ perun_registrar_backupTo: "{{ perun_email }}"
 # perun-cabinet.properties
 perun_cabinet_mu_login: ""
 perun_cabinet_mu_password: ""
-
-# perun-notification.properties
-perun_notification_emailFrom: "perun@localhost"
-perun_notification_fromText: "Test message"
-perun_notification_additional_lines: ""
 
 # LDAP
 perun_ldap_local: true

--- a/tasks/perun_rpc.yml
+++ b/tasks/perun_rpc.yml
@@ -84,13 +84,10 @@
     group: perunrpc
     mode: '0440'
 
-- name: "create perun-notification.properties"
-  template:
-    src: perun-notification.properties.j2
-    dest: /etc/perun/rpc/perun-notification.properties
-    owner: root
-    group: perunrpc
-    mode: '0440'
+- name: "delete unused perun-notifications.properties"
+  file:
+    path: /etc/perun/rpc/perun-notification.properties
+    state: absent
 
 - name: "create perun-extSources.xml"
   copy:

--- a/templates/perun-notification.properties.j2
+++ b/templates/perun-notification.properties.j2
@@ -1,5 +1,0 @@
-notif.emailFrom={{ perun_notification_emailFrom }}
-notif.fromText={{ perun_notification_fromText }}
-notif.sendMessages=true
-notif.dispatcherName=notifications
-{{ perun_notification_additional_lines }}

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -140,6 +140,9 @@ mail.smtp.port=25
 #perun.smtp.user=
 #perun.smtp.pass=
 
+# Enable sending generic notifications
+notif.sendMessages={{ perun_rpc_notif_send_messages }}
+
 # For which login-namespaces will perun auto-create necessary attributes (comma separated list)
 perun.autocreatedNamespaces=
 


### PR DESCRIPTION
- It is no longer used in new release v22.0.0, since the only used property was moved to perun.properties.
- Temporarily add task for perun_rpc to remove existing prop file.