### PR TITLE
Added option to disable old profile and admin gui

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -514,6 +514,8 @@ perun_apache_wui_enabled: yes
 perun_apache_special_config2: ""
 perun_apache_api_special_config: ""
 perun_apache_mounts_additional: []
+perun_apache_old_profile_disabled: no
+perun_apache_old_admin_gui_disabled: no
 
 perun_apache_shibboleth_sp_entity_id: "https://{{ perun_rpc_hostname }}/sp/shibboleth"
 perun_apache_shibboleth_sp_remote_user: "eppn epuid persistent-id targeted-id"

--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -144,13 +144,21 @@ ShibCompatValidUser on
   ####################################
   ##     Default GUI              ####
   ####################################
+{% if perun_apache_old_admin_gui_disabled %}
+  RewriteRule ^[/]?$ https://{{ perun_ngui_admin_hostname }} [L]
+{% else %}
   RewriteRule ^[/]?$ https://%{HTTP_HOST}/{{ perun_apache_gui_default_auth }}/gui/ [L]
+{% endif %}
 {% endif %}
 {% if perun_apache_default_profile_enabled %}
   ####################################
   ##     Default Profile          ####
   ####################################
+{% if perun_apache_old_profile_disabled %}
+  RewriteRule ^[/]?$ https://{{ perun_ngui_profile_hostname }} [L]
+{% else %}
   RewriteRule ^[/]?$ https://%{HTTP_HOST}/{{ perun_apache_profile_default_auth }}/profile/ [L]
+{% endif %}
 {% endif %}
 
   ####################################
@@ -167,10 +175,15 @@ ShibCompatValidUser on
   ####################################
   ##     GUI                      ####
   ####################################
+{% if perun_apache_old_admin_gui_disabled %}
+  RewriteRule ^/gui[/]?$ https://{{ perun_ngui_admin_hostname }} [L,R=301]
+  RewriteRule ^/(.*)/gui(.*)$ https://{{ perun_ngui_admin_hostname }} [L,R=301]
+{% else %}
   RewriteRule ^/gui[/]?$ https://%{HTTP_HOST}/{{ perun_apache_gui_default_auth }}/gui/ [L,R=301]
   RewriteRule ^/(.*)/gui$ https://%{HTTP_HOST}/$1/gui/ [L,R=301]
   RewriteRule ^/(.*)/gui/$ /var/www/perun-web-gui/PerunWeb.html [L]
   RewriteRule ^/(.*)/gui/(.+)$ /var/www/perun-web-gui/$2 [L]
+{% endif %}
 
   ####################################
   ##     Registrar                ####
@@ -226,10 +239,15 @@ ShibCompatValidUser on
   ####################################
   ##     PROFILE                  ####
   ####################################
+{% if perun_apache_old_profile_disabled %}
+  RewriteRule ^/profile[/]?$ https://{{ perun_ngui_profile_hostname }} [L,R=301]
+  RewriteRule ^/(.*)/profile(.*)$ https://{{ perun_ngui_profile_hostname }} [L,R=301]
+{% else %}
   RewriteRule ^/profile[/]?$ https://%{HTTP_HOST}/{{ perun_apache_profile_default_auth }}/profile/ [L,R=301]
   RewriteRule ^/(.*)/profile$ https://%{HTTP_HOST}/$1/profile/ [L,R=301]
   RewriteRule ^/(.*)/profile/$ /var/www/perun-wui/PerunProfile{{ perun_apache_profile_html_suffix }}.html [L]
   RewriteRule ^/(.*)/profile/(.+)$ /var/www/perun-wui/$2 [L]
+{% endif %}
 
 {% if perun_apache_wui_enabled %}
   ####################################


### PR DESCRIPTION
- Added variables perun_apache_old_admin_gui_disabled and perun_apache_old_profile_disabled that allows us to "disable" old applications. Meaning that when someone wants to access old profile or admin gui, he will be redirected to the new application. Default is that old application are enabled.