### PR TITLE
feat: added new rpc property userDeletionForced

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,7 @@ perun_rpc_native_language: 'cs,Česky,Czech'
 perun_rpc_userExtSources_persistent: "PERUN;"
 perun_rpc_extsources_multiple_identifiers: ""
 perun_rpc_lookup_user_by_identifiers_and_extSourceLogin: 'false'
+perun_rpc_user_deletion_forced: 'false'
 perun_rpc_force_consents: 'false'
 perun_rpc_requestUserInfoEndpoint: 'false'
 perun_rpc_defaultLoa_idp: "2"

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -155,6 +155,9 @@ perun.extsources.multiple.identifiers={{ perun_rpc_extsources_multiple_identifie
 # Try to lookup user by additional identifiers and if it is null, then lookup by user ext source name and login
 perun.lookup.user.by.identifiers.and.extSourceLogin={{ perun_rpc_lookup_user_by_identifiers_and_extSourceLogin }}
 
+# Enable user deletion (and associated blocking of user's logins) or use the default anonymization of user instead
+perun.user.deletion.forced={{ perun_rpc_user_deletion_forced }}
+
 # Require consents throughout Perun
 perun.force.consents={{ perun_rpc_force_consents }}
 


### PR DESCRIPTION
* This property switches between two possible scenarios.
* If this property is set to true, then the deletion of users will be enabled and set as well as a default method. During the deletion user's logins will be blocked. The anonymization will be disabled.
* If this property is set to false, then the anonymization of users will enabled and the deletion will be disabled.