### PR TITLE
Allow keeping session for new GUI apps

### DIFF
--- a/templates/sites-enabled/perun-api.conf.j2
+++ b/templates/sites-enabled/perun-api.conf.j2
@@ -86,6 +86,10 @@
     # sets Access-Control-Allow-Origin and Vary if Origin value matched
     Header onsuccess unset Access-Control-Allow-Origin "env=cors_origin_matched"
     Header always set Access-Control-Allow-Origin "expr=%{HTTP:Origin}" "env=cors_origin_matched"
+    # Allow tomcat session cookie to be sent with a request to API to prevent internal session reinitialization
+    Header onsuccess edit Set-Cookie (.*)Strict(.*) "$1None$2" "env=cors_origin_matched"
+    Header onsuccess set Access-Control-Allow-Credentials "true" "env=cors_origin_matched"
+
     # for pre-fly requests set more headers
     <If "-T reqenv('cors_origin_matched') && %{REQUEST_METHOD} == 'OPTIONS'">
         Header onsuccess unset Access-Control-Allow-Methods


### PR DESCRIPTION
- Manipulate tomcat PERUNSESSION cookie to be SameSite=None when cors origin matches. Also allow browser to send credentials.
- This allows us to keep internal tomcat session, and we do not have to reinitialize it with every request (also saving creation of two audit messages).
- This could technically allow cross site scripting, but we don't have any webapp on the API domain, we limit this modification only to our trusted domains, and we still expect request to contain authorization header, which is constructed inside the app and not transferred by cookies.