### PR TITLE
Add voPerson schema attributes to default attribute-map.xml

### DIFF
--- a/templates/shibboleth/attribute-map.xml.j2
+++ b/templates/shibboleth/attribute-map.xml.j2
@@ -9,13 +9,13 @@
     few exceptions for newer attributes where the name is the same for both versions. You will
     usually want to uncomment or map the names for both SAML versions as a unit.
     -->
-  
+
     <!-- New standard identifier attributes for SAML. -->
 
     <Attribute name="urn:oasis:names:tc:SAML:attribute:subject-id" id="subject-id">
         <AttributeDecoder xsi:type="ScopedAttributeDecoder" caseSensitive="false"/>
     </Attribute>
-  
+
     <Attribute name="urn:oasis:names:tc:SAML:attribute:pairwise-id" id="pairwise-id">
         <AttributeDecoder xsi:type="ScopedAttributeDecoder" caseSensitive="false"/>
     </Attribute>
@@ -199,6 +199,12 @@
     <Attribute name="urn:oid:1.3.6.1.4.1.34998.3.3.1.11" id="voPersonExternalAffiliation"/>
     <Attribute name="urn:oid:1.3.6.1.4.1.34998.3.3.1.16" id="voPersonID"/>
     <Attribute name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" id="eIDASPersonIdentifier"/>
+
+    <!-- official voPerson schema attributes -->
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.4.1.6" id="voPersonID"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.4.1.3" id="voPersonCertificateDN"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.4.1.4" id="voPersonCertificateIssuerDN"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.4.1.14" id="voPersonVerifiedEmail"/>
 
 {{ perun_apache_shibboleth_sp_attribute_map_additions }}
 


### PR DESCRIPTION
- EGI uses officiali voPerson schema OIDs while Geant is using attributes in their own schema. Official attributes are now part of the default config.