### PR TITLE
Do not set swap limit since it's not supported by kernel

### DIFF
--- a/tasks/perun_rpc.yml
+++ b/tasks/perun_rpc.yml
@@ -208,7 +208,8 @@
     # check with "docker exec -it perun_rpc jcmd 1 VM.flags" the value of -XX:MaxRAM
     # JVM then uses -XX:MaxRAMPercentage to compute -XX:MaxHeapSize
     memory: "{{ (ansible_memtotal_mb * 0.6)|int }}M"
-    memory_swap: "{{ (ansible_memtotal_mb * 0.6)|int }}M"
+    #memory_swap: "{{ (ansible_memtotal_mb * 0.6)|int }}M"
+    memory_swappiness: 0
     container_default_behavior: no_defaults
   register: perun_rpc_container
 


### PR DESCRIPTION
- We couldn't set swap limit to the container since it was not supported in kernel. It resulted in false "changed" flag for the container creation on each run and container was not restarted beacuse of it.
- Now we don't set swap limit, since enabling it in kernel means 1% memory and 10% performance degradation and we don't actually need it.