### PR TITLE
Removed wui admin part of apache config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -512,7 +512,6 @@ perun_apache_consolidator_html_suffix: ""
 perun_apache_profile_default_auth: "fed"
 perun_apache_profile_html_suffix: ""
 perun_apache_pwdreset_html_suffix: ""
-perun_apache_wui_enabled: yes
 perun_apache_special_config2: ""
 perun_apache_api_special_config: ""
 perun_apache_mounts_additional: []

--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -97,9 +97,9 @@ ShibCompatValidUser on
   Header always set Permissions-Policy "accelerometer=(), autoplay=(), camera=(), geolocation=(), microphone=(), payment=()"
 
   # Disable browser caching for our html/rpc resources
-  Header always set Cache-Control "no-cache, no-store, max-age=0, must-revalidate" "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|wui|ic|registrar|publications|profile|affiliation)(/|(.*).nocache.js)|rpc/(.*))$#"
-  Header always set Pragma no-cache "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|wui|ic|registrar|publications|profile|affiliation)(/|(.*).nocache.js)|rpc/(.*))$#"
-  Header always set Expires 0 "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|wui|ic|registrar|publications|profile|affiliation)(/|(.*).nocache.js)|rpc/(.*))$#"
+  Header always set Cache-Control "no-cache, no-store, max-age=0, must-revalidate" "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|ic|registrar|publications|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
+  Header always set Pragma no-cache "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|ic|registrar|publications|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
+  Header always set Expires 0 "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|ic|registrar|publications|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
 
 {% if perun_rpc_cors_domains %}
   # CORS headers
@@ -247,16 +247,6 @@ ShibCompatValidUser on
   RewriteRule ^/(.*)/profile$ https://%{HTTP_HOST}/$1/profile/ [L,R=301]
   RewriteRule ^/(.*)/profile/$ /var/www/perun-wui/PerunProfile{{ perun_apache_profile_html_suffix }}.html [L]
   RewriteRule ^/(.*)/profile/(.+)$ /var/www/perun-wui/$2 [L]
-{% endif %}
-
-{% if perun_apache_wui_enabled %}
-  ####################################
-  ##     WUI                      ####
-  ####################################
-  RewriteRule ^/(.*)/wui$ https://%{HTTP_HOST}/$1/wui/ [L,R=301]
-  RewriteRule ^/(.*)/wui/$ /var/www/perun-wui/PerunAdmin.html [L]
-  RewriteRule ^/(.*)/wui/(.+)$ /var/www/perun-wui/$2 [L]
-
 {% endif %}
 
   ####################################


### PR DESCRIPTION
- We do not build WUI Admin app for a long time, so there is no need to have it in apache config (under /wui/ path).
- Removed also from cache headers conditions together with affiliation app, which has been deleted too.
- Removed default value property for "perun_apache_wui_enabled".