### PR TITLE
Edit MFA properties names + remove unused properties

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,10 +112,8 @@ perun_rpc_db_initializator_enabled: yes
 perun_rpc_userInfoEndpoint_extSourceLogin: ""
 perun_rpc_userInfoEndpoint_extSourceName: ""
 perun_rpc_userInfoEndpoint_extSourceFriendlyName: ""
-perun_rpc_userInfoEndpoint_mfaAuthTimestampPropertyName: ""
-perun_rpc_userInfoEndpoint_mfaAuthTimeout: 24
-perun_rpc_userInfoEndpoint_acrPropertyName: ""
-perun_rpc_userInfoEndpoint_mfaAcrValue: ""
+perun_rpc_introspectionEndpoint_mfaAuthTimeout: 24
+perun_rpc_introspectionEndpoint_mfaAcrValue: ""
 perun_rpc_enforceMfa: 'false'
 perun_rpc_mounts_additional: []
 perun_rpc_idpLoginValidity: 24

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -199,17 +199,11 @@ perun.userInfoEndpoint.extSourceName={{ perun_rpc_userInfoEndpoint_extSourceName
 # properties that are path in the userInfo to the extSourceFriendlyName
 perun.userInfoEndpoint.extSourceFriendlyName={{ perun_rpc_userInfoEndpoint_extSourceFriendlyName }}
 
-# name of the property in userInfo that could contain MFA timestamp
-perun.userInfoEndpoint.mfaAuthTimestampPropertyName={{ perun_rpc_userInfoEndpoint_mfaAuthTimestampPropertyName }}
-
 # timeout limit (hours) for the MFA to be valid (timestamp cannot be older than the limit)
-perun.userInfoEndpoint.mfaAuthTimeout={{ perun_rpc_userInfoEndpoint_mfaAuthTimeout }}
+perun.introspectionEndpoint.mfaAuthTimeout={{ perun_rpc_introspectionEndpoint_mfaAuthTimeout }}
 
-# name of the property in userInfo that should contain acr
-perun.userInfoEndpoint.acrPropertyName={{ perun_rpc_userInfoEndpoint_acrPropertyName }}
-
-# expected acr value to be returned from userInfo if MFA was performed
-perun.userInfoEndpoint.mfaAcrValue={{ perun_rpc_userInfoEndpoint_mfaAcrValue }}
+# expected acr value to be returned from introspection endpoint if MFA was performed
+perun.introspectionEndpoint.mfaAcrValue={{ perun_rpc_introspectionEndpoint_mfaAcrValue }}
 
 # when set to true, MFA is required for critical operations and attribute actions
 perun.enforceMfa={{ perun_rpc_enforceMfa }}


### PR DESCRIPTION
* mfa information is now retrieved from the introspection endpoint, rename properties to reflect this
* acr and auth timestamp claim names should follow OpenID standards and hence do not have to be configurable