### PR TITLE
Make sure static resources are available during maintenance

### DIFF
--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -140,6 +140,9 @@ ShibCompatValidUser on
   RewriteCond %{REQUEST_URI} !^/ba/
   RewriteCond %{REQUEST_URI} !^/maintenance/
   RewriteCond %{REQUEST_URI} !^/Shibboleth.sso/
+  RewriteCond %{REQUEST_URI} !^/external/
+  RewriteCond %{REQUEST_URI} !^/static/
+  RewriteCond %{REQUEST_URI} !^/img/
   RewriteRule .* /maintenance/maintenance.html [R,L]
 {% endif %}
 


### PR DESCRIPTION
- Added /img and /static to opened endpoints when in maintenance.
- Added also /external which is used on EGI.