### PR TITLE
Allow forcing only local logout on Perun SP

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -525,6 +525,8 @@ perun_apache_shibboleth_sp_entity_id: "https://{{ perun_rpc_hostname }}/sp/shibb
 perun_apache_shibboleth_sp_remote_user: "eppn epuid persistent-id targeted-id"
 perun_apache_shibboleth_sp_session_timeout: 3600
 perun_apache_shibboleth_sp_idp_entity_id: "https://login.example.org/idp/"
+# disable SAML 2 logout (for instances with SP on multiple hostnames like EGI/CESNET, since proxy will call redirect only on primary domain)
+perun_apache_shibboleth_sp_force_local_logout: no
 perun_apache_shibboleth_sp_session_initiators: |2
           <!-- no special session initiators -->
 perun_apache_shibboleth_sp_metadata_providers: |2

--- a/templates/shibboleth/shibboleth2.xml.j2
+++ b/templates/shibboleth/shibboleth2.xml.j2
@@ -49,7 +49,9 @@
 {{ perun_apache_shibboleth_sp_session_initiators }}
             <!-- LogoutInitiators enable SP-initiated local or global/single logout of sessions. -->
             <LogoutInitiator type="Chaining" Location="/Logout">
+{% if not perun_apache_shibboleth_sp_force_local_logout %}
                 <LogoutInitiator type="SAML2" template="bindingTemplate.html"/>
+{% endif %}
                 <LogoutInitiator type="Local"/>
             </LogoutInitiator>
 
@@ -96,7 +98,7 @@
 
 {{ perun_apache_shibboleth_sp_application_overrides  }}
     </ApplicationDefaults>
-    
+
     <!-- Policies that determine how to process and authenticate runtime messages. -->
     <SecurityPolicyProvider type="XML" validate="true" path="security-policy.xml"/>
 


### PR DESCRIPTION
- For instances like CESNET/EGI where multiple domains are used, SAML2 logout doesn't work since proxy won't return us to the expected domain, but rather the primary one. We can't specify multiple endpoints in the metadata, only first found is used in logout redirect. Problem is solved by using only local logout with forcing authn on consolidator endpoints.
- Default is still using SAML2 logout. To force local logout only set "perun_apache_shibboleth_sp_session_initiators" to "yes".