### PR TITLE
enabled Certificate Revocation Lists checking

### DIFF
--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -67,6 +67,8 @@ ShibCompatValidUser on
   SSLVerifyDepth 5
   SSLVerifyClient optional
   SSLOptions +LegacyDNStringFormat
+  SSLCARevocationCheck chain
+  SSLCARevocationPath /etc/grid-security/certificates/
 {% endif %}
 
   # Increasing limits on HTTP headers. Connector packetSize in Tomcat must be set to bigger value than ProxyIOBufferSize here.


### PR DESCRIPTION
CRLs were not checked so far, this change adds directives to check them. The service **fetch-crl-cron** must be installed and started for this to work.