### PR TITLE
Prepare perun.properties for allowed roles config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -126,6 +126,16 @@ perun_rpc_idpLoginValidityExceptions: []
 perun_rpc_notif_send_messages: 'true'
 perun_rpc_force_html_sanitization: false
 
+# TODO - enable when we ditch old admin gui and enable step-up for MFA
+perun_rpc_app_allowed_roles: []
+#perun_rpc_app_allowed_roles:
+#  - name: 'registrar'
+#    reg: '^.*/registrar/.*$'
+#    roles: [ 'SELF', 'MFA' ]
+#  - name: 'ic'
+#    reg: '^.*/ic/.*$'
+#    roles: [ 'SELF', 'MFA' ]
+
 perun_namespaces_properties: ""
 
 # old GUI
@@ -315,7 +325,7 @@ perun_ngui_profile_page_attributes:
 perun_ngui_profile_mfa: {}
 perun_ngui_profile_display_identity_certificates: true
 perun_ngui_profile_external_services: []
-perun_ngui_profile_displayed_tabs: ['profile', 'identities', 'groups', 'privacy', 'settings', 'ssh_keys']
+perun_ngui_profile_displayed_tabs: ['profile', 'identities', 'groups', 'privacy', 'authentication', 'settings', 'ssh_keys']
 perun_ngui_profile_custom_labels: []
 perun_ngui_profile_supported_languages: ['en']
 perun_ngui_profile_header_label_en: "User Profile"

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -222,3 +222,10 @@ perun.idpLoginValidityExceptions={{ perun_rpc_idpLoginValidityExceptions|join(',
 
 # force HTML sanitization
 perun.forceHtmlSanitization={{ perun_rpc_force_html_sanitization|bool|to_json }}
+
+# Limit roles in session for the old GUI apps. This is necessary to support step-up MFA globally.
+perun.appAllowedRoles.apps={% for app in perun_rpc_app_allowed_roles %}{{ app.name }}{% if not loop.last %},{% endif %}{% endfor %}
+{% for app in perun_rpc_app_allowed_roles %}
+perun.appAllowedRoles.{{ app.name }}.reg={{ app.reg }}
+perun.appAllowedRoles.{{ app.name }}.roles={{ app.roles|join(',') }}
+{% endfor %}


### PR DESCRIPTION
- For now this feature is disabled and should be enabled only on instances where step-up MFA is enabled.
- Added "authentication" to default NGUI profile pages since ssh_keys wouldn't work without it.