### PR TITLE
Support custom API url for NGUI admin and profile

### DIFF
--- a/templates/instance_configs/consolidatorInstanceConfig.json.j2
+++ b/templates/instance_configs/consolidatorInstanceConfig.json.j2
@@ -1,8 +1,8 @@
 {# https://perunaai.atlassian.net/wiki/spaces/STRIBOG/pages/3440714/Configuration+of+new+GUI+applications #}
 {
   "config": "{{ perun_ngui_consolidator_hostname }}",
-{% if perun_ngui_consolidator_api_url is defined %}
-  "api_url": "https://{{ perun_ngui_consolidator_api_url }}/oauth/rpc",
+{% if perun_ngui_consolidator_api_hostname is defined %}
+  "api_url": "https://{{ perun_ngui_consolidator_api_hostname }}/oauth/rpc",
 {% else %}
   "api_url": "https://{{ perun_api_hostname }}/oauth/rpc",
 {% endif %}

--- a/templates/instance_configs/instanceConfig.json.j2
+++ b/templates/instance_configs/instanceConfig.json.j2
@@ -1,7 +1,9 @@
 {# https://perunaai.atlassian.net/wiki/spaces/STRIBOG/pages/3440714/Configuration+of+new+GUI+applications #}
 {
   "config": "admin {{ perun_ngui_admin_hostname }}",
-{% if perun_ngui_admin_api_hostname is defined %}
+{% if perun_ngui_admin_api_url is defined %}
+  "api_url": "{{ perun_ngui_admin_api_url }}",
+{% elif perun_ngui_admin_api_hostname is defined %}
   "api_url": "https://{{ perun_ngui_admin_api_hostname }}/oauth/rpc",
 {% else %}
   "api_url": "https://{{ perun_api_hostname }}/oauth/rpc",

--- a/templates/instance_configs/linkerInstanceConfig.json.j2
+++ b/templates/instance_configs/linkerInstanceConfig.json.j2
@@ -1,8 +1,8 @@
 {# https://perunaai.atlassian.net/wiki/spaces/STRIBOG/pages/3440714/Configuration+of+new+GUI+applications #}
 {
   "config": "{{ perun_ngui_linker_hostname }}",
-{% if perun_ngui_linker_api_url is defined %}
-  "api_url": "https://{{ perun_ngui_linker_api_url }}/oauth/rpc",
+{% if perun_ngui_linker_api_hostname is defined %}
+  "api_url": "https://{{ perun_ngui_linker_api_hostname }}/oauth/rpc",
 {% else %}
   "api_url": "https://{{ perun_api_hostname }}/oauth/rpc",
 {% endif %}

--- a/templates/instance_configs/profileInstanceConfig.json.j2
+++ b/templates/instance_configs/profileInstanceConfig.json.j2
@@ -2,7 +2,9 @@
 {
   "document_title": {{ perun_ngui_profile_document_title|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "instance_favicon": {{ perun_ngui_profile_instance_favicon|to_json }},
-{% if perun_ngui_profile_api_hostname is defined %}
+{% if perun_ngui_profile_api_url is defined %}
+  "api_url": "{{ perun_ngui_profile_api_url }}",
+{% elif perun_ngui_profile_api_hostname is defined %}
   "api_url": "https://{{ perun_ngui_profile_api_hostname }}/oauth/rpc",
 {% else %}
   "api_url": "https://{{ perun_api_hostname }}/oauth/rpc",

--- a/templates/sites-enabled/perun-consolidator.conf.j2
+++ b/templates/sites-enabled/perun-consolidator.conf.j2
@@ -79,7 +79,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_consolidator_oauth_csp_url }} https://{{ perun_ngui_consolidator_api_url if perun_ngui_consolidator_api_url is defined else perun_api_hostname }}; img-src 'self' data: https: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_consolidator_oauth_csp_url }} https://{{ perun_ngui_consolidator_api_hostname if perun_ngui_consolidator_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: https: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-linker.conf.j2
+++ b/templates/sites-enabled/perun-linker.conf.j2
@@ -78,7 +78,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_linker_oauth_csp_url }} https://{{ perun_ngui_linker_api_url if perun_ngui_linker_api_url is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_linker_oauth_csp_url }} https://{{ perun_ngui_linker_api_hostname if perun_ngui_linker_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/


### PR DESCRIPTION
- We can now specify full custom API URL, which will be used in instanceConfig.json and profileInstanceConfig.json. It allows us to switch service-access to a different authz provider (eg. ldap on VSUP).
- Changed "url" to "hostname" in API variables for new consolidator and linker, since it actually changes only the hostname and not full URL.