### PR TITLE
Support for Auditlogger application

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -465,6 +465,9 @@ perun_engine_ssh_privkey_file: id_ed25519
 perun_engine_ssh_pubkey_file: id_ed25519.pub
 perun_engine_mounts_additional: []
 
+# Auditlogger
+perun_auditlogger_enabled: no
+
 ##########
 # Apache #
 ##########

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -30,6 +30,14 @@
     container_default_behavior: no_defaults
   when: perun_ldapc_enabled and perun_ldapc_container is defined and not perun_ldapc_container.changed
 
+- name: "restart perun_auditlogger"
+  docker_container:
+    name: perun_auditlogger
+    state: started
+    restart: yes
+    container_default_behavior: no_defaults
+  when: perun_auditlogger_enabled and perun_auditlogger_container is defined and not perun_auditlogger_container.changed
+
 - name: "restart portainer"
   docker_container:
     name: portainer

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -205,6 +205,17 @@
     - perun_ldapc
     - perun_config
 
+- name: "perun auditlogger setup"
+  include_tasks:
+    file: perun_auditlogger.yml
+    apply:
+      tags:
+        - perun_auditlogger
+        - perun_config
+  tags:
+    - perun_auditlogger
+    - perun_config
+
 - name: "perun apache setup"
   import_tasks: perun_apache.yml
   tags:

--- a/tasks/perun_auditlogger.yml
+++ b/tasks/perun_auditlogger.yml
@@ -1,0 +1,124 @@
+- name: "create perun-auditlogger.properties"
+  template:
+    src: perun-auditlogger.properties.j2
+    dest: /etc/perun/auditlogger/perun-auditlogger.properties
+    owner: root
+    group: perunalg
+    mode: '0440'
+  notify: "restart perun_auditlogger"
+
+# files jdbc.properties, perun.properties, perun-roles.yml and login-namespaces-rules-config.yml are needed because perun-auditlogger includes Perun core
+- name: "create jdbc.properties for Auditlogger"
+  template:
+    src: jdbc.properties.j2
+    dest: /etc/perun/auditlogger/jdbc.properties
+    owner: root
+    group: perunalg
+    mode: '0440'
+  notify: "restart perun_auditlogger"
+
+- name: "create perun.properties for Auditlogger"
+  template:
+    src: perun.properties.j2
+    dest: /etc/perun/auditlogger/perun.properties
+    owner: root
+    group: perunalg
+    mode: '0440'
+  notify: "restart perun_auditlogger"
+
+- name: "create perun-apps-config.yml for Auditlogger"
+  template:
+    src: perun-apps-config.yml.j2
+    dest: /etc/perun/auditlogger/perun-apps-config.yml
+    owner: root
+    group: perunalg
+    mode: '0440'
+  notify: "restart perun_auditlogger"
+
+- name: "create perun-roles.yml for Auditlogger"
+  template:
+    src: perun-roles.yml.j2
+    dest: /etc/perun/auditlogger/perun-roles.yml
+    owner: root
+    group: perunalg
+    mode: '0440'
+  notify: "restart perun_auditlogger"
+
+- name: "create login-namespaces-rules-config.yml"
+  copy:
+    src: "{{ lookup('first_found', findme) }}"
+    dest: /etc/perun/auditlogger/login-namespaces-rules-config.yml
+    owner: root
+    group: perunalg
+    mode: '0440'
+  vars:
+    findme:
+      - "{{ perun_instance_hostname }}/login-namespaces-rules-config.yml"
+      - "login-namespaces-rules-config.yml"
+  notify: "restart perun_auditlogger"
+
+- name: "create logback-auditlogger.xml"
+  template:
+    src: logback-auditlogger.xml.j2
+    dest: /etc/perun/auditlogger/logback-auditlogger.xml
+    owner: root
+    group: perunalg
+    mode: '0440'
+  notify: "restart perun_auditlogger"
+
+- name: "create perun-auditlogger"
+  template:
+    src: perun-auditlogger.j2
+    dest: /etc/perun/auditlogger/perun-auditlogger
+    owner: root
+    group: perunalg
+    mode: '0440'
+  notify: "restart perun_auditlogger"
+
+- name: "create perun-auditlogger-last-state"
+  copy:
+    force: no
+    dest: /home/perunalg/perun-auditlogger-last-state
+    content: "0"
+    owner: perunalg
+    group: perunalg
+
+- name: "get perun_net info"
+  docker_network_info:
+    name: perun_net
+  register: perun_net_info
+
+- name: "{{ 'create' if perun_auditlogger_enabled else 'remove' }} Perun Auditlogger container"
+  docker_container:
+    name: perun_auditlogger
+    hostname: perun-auditlogger
+    image: "registry.gitlab.ics.muni.cz:443/perun/perun_docker/perun_auditlogger:{{ perun_auditlogger_container_version }}"
+    pull: yes
+    restart_policy: unless-stopped
+    mounts:
+      - { type: volume, source: perunalg_home, target: /home/perun }
+      - { type: volume, source: perunalg_etc,  target: /etc/perun }
+      # bind syslog and journal from container to host, see https://www.projectatomic.io/blog/2016/10/playing-with-docker-logging/
+      - { type: bind, source: /dev/log, target: /dev/log }
+      - { type: bind, source: /var/run/systemd/journal/socket, target: /var/run/systemd/journal/socket }
+    networks_cli_compatible: yes
+    networks:
+      - name: perun_net
+    network_mode: perun_net
+    etc_hosts: "{{ perun_containers_etc_hosts | combine( { 'perun-host': perun_net_info.network.IPAM.Config[0].Gateway }) }}"
+    container_default_behavior: no_defaults
+    state: "{{ 'started' if perun_auditlogger_enabled else 'absent' }}"
+  register: perun_auditlogger_container
+
+- name: "remove old hostname"
+  lineinfile:
+    dest: /etc/hosts
+    regexp: 'perun_auditlogger'
+    state: absent
+
+- name: "put container IP into /etc/hosts"
+  when: perun_auditlogger_enabled
+  lineinfile:
+    dest: /etc/hosts
+    regexp: "{{ perun_auditlogger_container.container.Config.Hostname }}"
+    line: "{{ perun_auditlogger_container.container.NetworkSettings.Networks.perun_net.IPAddress }} {{ perun_auditlogger_container.container.Config.Hostname }}"

--- a/tasks/perun_certs.yml
+++ b/tasks/perun_certs.yml
@@ -58,6 +58,9 @@
           {% if perun_ldapc_enabled %}
           docker stop perun_ldapc
           {% endif %}
+          {% if perun_auditlogger_enabled %}
+          docker stop perun_auditlogger
+          {% endif %}
           systemctl restart postgresql
           systemctl restart slapd
           systemctl restart syslog-ng
@@ -70,6 +73,9 @@
           {% endif %}
           {% if perun_ldapc_enabled %}
           docker start perun_ldapc
+          {% endif %}
+          {% if perun_auditlogger_enabled %}
+          docker start perun_auditlogger
           {% endif %}
           docker start perun_apache
           docker restart portainer

--- a/tasks/perun_users.yml
+++ b/tasks/perun_users.yml
@@ -9,6 +9,7 @@
     - { name: peruneng, gid: 962 }
     - { name: perunldc, gid: 963 }
     - { name: _shibd, gid: 964 }
+    - { name: perunalg, gid: 965 }
 
 - name: "create perun users"
   user:
@@ -26,11 +27,12 @@
     - { name: peruneng, uid: 962, comment: "Perun Engine", create_home: no, home: /nonexistent, shell: /usr/sbin/nologin }
     - { name: perunldc, uid: 963, comment: "Perun LDAP Connector", create_home: no, home: /nonexistent, shell: /usr/sbin/nologin }
     - { name: _shibd,   uid: 964, comment: "Shibboleth daemon", create_home: no, home: /nonexistent, shell: /usr/sbin/nologin }
+    - { name: perunalg, uid: 965, comment: "Perun Auditlogger", create_home: no, home: /nonexistent, shell: /usr/sbin/nologin }
 
 - name: "disable ssh to perun* users"
   lineinfile:
     path: /etc/ssh/sshd_config
-    line: "DenyUsers perunrpc peruneng perunldc"
+    line: "DenyUsers perunrpc peruneng perunldc perunalg"
     state: present
   notify: "restart sshd"
 
@@ -53,4 +55,6 @@
       alias rpc-bash-root='docker exec -u root -it perun_rpc bash'
       alias ldapc-bash='docker exec -it -w /home/perun perun_ldapc bash'
       alias ldapc-bash-root='docker exec -u root -it perun_ldapc bash'
+      alias auditlogger-bash='docker exec -it -w /home/perun perun_auditlogger bash'
+      alias auditlogger-bash-root='docker exec -u root -it perun_auditlogger bash'
       alias x509='openssl x509 -noout -nameopt compat -subject -issuer -dates -ext subjectAltName -in'

--- a/tasks/perun_volumes.yml
+++ b/tasks/perun_volumes.yml
@@ -15,9 +15,11 @@
     - { name: 'perunrpc_home', link: "/home/perunrpc", owner: perunrpc, group: perunrpc, mode: '770' }
     - { name: 'peruneng_home', link: "/home/peruneng", owner: peruneng, group: peruneng, mode: '770' }
     - { name: 'perunldc_home', link: "/home/perunldc", owner: perunldc, group: perunldc, mode: '770' }
+    - { name: 'perunalg_home', link: "/home/perunalg", owner: perunalg, group: perunalg, mode: '770' }
     - { name: 'perunrpc_etc',  link: "/etc/perun/rpc", owner: root, group: perunrpc, mode: '550' }
     - { name: 'peruneng_etc',  link: "/etc/perun/engine", owner: root, group: peruneng, mode: '550' }
     - { name: 'perunldc_etc',  link: "/etc/perun/ldapc", owner: root, group: perunldc, mode: '550' }
+    - { name: 'perunalg_etc',  link: "/etc/perun/auditlogger", owner: root, group: perunalg, mode: '550' }
   loop_control:
     loop_var: volume
     label: "{{ volume.name }}"

--- a/templates/logback-auditlogger.xml.j2
+++ b/templates/logback-auditlogger.xml.j2
@@ -1,0 +1,33 @@
+<configuration packagingData="false" debug="false" scan="false" scanPeriod="30 seconds">
+
+	<appender class="org.gnieh.logback.SystemdJournalAppender" name="journal">
+		<syslogIdentifier>perun_auditlogger</syslogIdentifier>
+		<logLoggerName>true</logLoggerName>
+		<encoder>
+			<pattern>%-5level %logger{35} - %msg</pattern>
+		</encoder>
+	</appender>
+
+	<appender class="org.gnieh.logback.SystemdJournalAppender" name="journal-audit">
+		<syslogIdentifier>perun_audit</syslogIdentifier>
+		<logLoggerName>true</logLoggerName>
+		<logStacktrace>false</logStacktrace>
+		<encoder>
+			<pattern>%msg</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="journal" />
+	</root>
+
+	<logger name="cz.metacentrum.perun.auditlogger" level="debug"/>
+
+	<logger name="syslog-logger" level="debug" additivity="false">
+		<appender-ref ref="journal-audit" />
+	</logger>
+
+	<!-- keep Spring quiet -->
+	<logger name="org.springframework" level="warn"/>
+
+</configuration>

--- a/templates/perun-auditlogger.j2
+++ b/templates/perun-auditlogger.j2
@@ -1,0 +1,6 @@
+{{ ansible_managed | comment }}
+
+# Set if you wish to start the Auditlogger with specific last processed ID.
+# Comment it out, if you wish to start Auditlogger just from the point it stopped.
+#
+#LAST_PROCESSED_ID=""

--- a/templates/perun-auditlogger.properties.j2
+++ b/templates/perun-auditlogger.properties.j2
@@ -1,0 +1,5 @@
+{{ ansible_managed | comment }}
+
+# AuditLogger configuration
+auditlogger.consumer=auditlogger
+auditlogger.statefile=./perun-auditlogger-last-state


### PR DESCRIPTION
- Auditlogger app is NOT installed by default.
- Added necessary config files and installation tasks.
- Create perunalg group and user.
- Restart it when certificates changes.
- Mount /home/perunalg and /etc/perun/auditlogger/.