### PR TITLE
Include perun-oidc-config.yml in perun_rpc configuration

### DIFF
--- a/tasks/perun_rpc.yml
+++ b/tasks/perun_rpc.yml
@@ -128,6 +128,19 @@
       - "login-namespaces-rules-config.yml"
   notify: "restart perun_rpc"
 
+- name: "create perun-oidc-config.yml"
+  copy:
+    src: "{{ lookup('first_found', findme) }}"
+    dest: /etc/perun/rpc/perun-oidc-config.yml
+    owner: root
+    group: perunrpc
+    mode: 0440
+  vars:
+    findme:
+      - "{{ perun_instance_hostname }}/perun-oidc-config.yml"
+      - "perun-oidc-config.yml"
+  notify: "restart perun_rpc"
+
 - name: "create directory /etc/perun/rpc/modules/"
   file:
     path: /etc/perun/rpc/modules


### PR DESCRIPTION
- /etc/perun/perun-oidc-config.yml file inside the perun_rpc container is used by OIDC version of CLI for autoconfiguration purposes.
- Source file is expected to be in the "files" root for each instance.