### PR TITLE
Removed task "delete unused perun-notifications.properties"

### DIFF
--- a/tasks/perun_rpc.yml
+++ b/tasks/perun_rpc.yml
@@ -97,11 +97,6 @@
     mode: '0440'
   notify: "restart perun_rpc"
 
-- name: "delete unused perun-notifications.properties"
-  file:
-    path: /etc/perun/rpc/perun-notification.properties
-    state: absent
-
 - name: "create perun-extSources.xml"
   copy:
     src: "{{ lookup('first_found', findme) }}"


### PR DESCRIPTION
- Task is no longer needed, since it was deployed everywhere with version v22.0.0, and we are now at v28.0.2.