### PR TITLE
Allow customization of support email for password reset

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -173,6 +173,7 @@ perun_oldgui_disableCreateVo: 'false'
 perun_oldgui_rt_defaultQueue: "perun"
 perun_oldgui_rt_defaultMail: "perun@cesnet.cz"
 perun_oldgui_report_email_address: "{{ perun_email }}"
+perun_oldgui_pwdreset_support_mail: "{{ perun_email }}"
 perun_oldgui_fedAuthz: [ 'fed' ]
 perun_oldgui_supportedPasswordNamespaces: ''
 perun_oldgui_wayf_spLogoutUrl: "/Consolidator.sso/Logout"

--- a/templates/perun-web-gui.properties.j2
+++ b/templates/perun-web-gui.properties.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 
 perunReportEmailAddress={{ perun_oldgui_report_email_address }}
-pwdreset.support.mail={{ perun_email }}
+pwdreset.support.mail={{ perun_oldgui_pwdreset_support_mail }}
 defaultRtQueue={{ perun_oldgui_defaultRtQueue }}
 vosManagerMembersGroup=members
 getAttributesListForMemberTables={{ perun_oldgui_getAttributesListForMemberTables|join(',') }}


### PR DESCRIPTION
- We want address different from generic perun backup email.
- Default fallback to previous behavior.