### PR TITLE
Make remote logging config configurable per instance

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -468,11 +468,15 @@ perun_engine_ssh_privkey_file: id_ed25519
 perun_engine_ssh_pubkey_file: id_ed25519.pub
 perun_engine_mounts_additional: []
 
-# remote logging to vinovago.cesnet.cz
-perun_syslog_vinovago_enabled: false
+# remote logging
+perun_remote_logging_enabled: no
+perun_remote_logging_server: vinovago.cesnet.cz
+perun_remote_logging_port: 514
+perun_remote_logging_conf: vinovago
+perun_remote_logging_filter: ""
 
 # Auditlogger - by default enabled on instances logging remotely
-perun_auditlogger_enabled: "{{ perun_syslog_vinovago_enabled }}"
+perun_auditlogger_enabled: "{{ perun_remote_logging_enabled }}"
 
 ##########
 # Apache #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,8 +55,11 @@
     name: cesnet.remote_logging
   vars:
     remote_logging_hostname: "{{ etc_hostname_hostname }}"
-    remote_logging_enabled: "{{ perun_syslog_vinovago_enabled }}"
-
+    remote_logging_enabled: "{{ perun_remote_logging_enabled }}"
+    remote_logging_server: "{{ perun_remote_logging_server }}"
+    remote_logging_port: "{{ perun_remote_logging_port }}"
+    remote_logging_conf: "{{ perun_remote_logging_conf }}"
+    remote_logging_filter: "{{ perun_remote_logging_filter }}"
 
 - name: "creation of users perun, peruneng, etc."
   import_tasks: perun_users.yml


### PR DESCRIPTION
- Introduce perun_* variables in config for cesnet.remote_logging.
- Ditch vinovago from variable names.
- Use default config from the role in perun_docker_server.