### PR TITLE
Support new replyTo properties for core and registrar

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,6 +83,7 @@ perun_rpc_defaultLoa_idp: "2"
 perun_rpc_recaptcha_privatekey: '6Lf0eUYUAAAAAIBxpRrA7UNrT7czQ28IoH9yiDBE'
 perun_rpc_mailchange_secretKey: "test"
 perun_rpc_mailchange_backupFrom: "{{ perun_email }}"
+perun_rpc_mailchange_replyTo: ""
 perun_rpc_mailchange_validationWindow: 24
 perun_rpc_pwdreset_secret_key: '123456789120123456'
 perun_rpc_pwdreset_init_vector: '0123456789ABCDEF'
@@ -441,7 +442,10 @@ perun_api_for_engine_hostname: "{{ perun_api_hostname }}"
 perun_registrar_secretKey: "test"
 perun_registrar_fedAuthz: 'fed'
 perun_registrar_backupFrom: "{{ perun_email }}"
+perun_registrar_backupFromName: ""
 perun_registrar_backupTo: "{{ perun_email }}"
+perun_registrar_replyTo: ""
+perun_registrar_replyToName: ""
 
 # perun-cabinet.properties
 perun_cabinet_mu_login: ""

--- a/templates/perun-registrar-lib.properties.j2
+++ b/templates/perun-registrar-lib.properties.j2
@@ -6,7 +6,10 @@ secretKey={{ perun_registrar_secretKey }}
 
 # Backup email adresses
 backupFrom={{ perun_registrar_backupFrom }}
+backupFromName={{ perun_registrar_backupFromName }}
 backupTo={{ perun_registrar_backupTo }}
+replyTo={{ perun_registrar_replyTo }}
+replyToName={{ perun_registrar_replyToName }}
 
 # Federative authz
 fedAuthz={{ perun_registrar_fedAuthz }}

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -63,6 +63,7 @@ perun.recaptcha.privatekey = {{ perun_rpc_recaptcha_privatekey }}
 # Perun properties for email validation message
 perun.mailchange.secretKey = {{ perun_rpc_mailchange_secretKey }}
 perun.mailchange.backupFrom = {{ perun_rpc_mailchange_backupFrom }}
+perun.mailchange.replyTo = {{ perun_rpc_mailchange_replyTo }}
 perun.mailchange.validationWindow = {{ perun_rpc_mailchange_validationWindow }}
 
 perun.native.language = {{ perun_rpc_native_language }}


### PR DESCRIPTION
- New properties allow to configure default "replyTo" values for sent notifications from registrar or core (mailchange, pwd change).