### PR TITLE
Clear default external deps for auditlogger and ldapc

### DIFF
--- a/tasks/perun_auditlogger.yml
+++ b/tasks/perun_auditlogger.yml
@@ -24,6 +24,9 @@
     owner: root
     group: perunalg
     mode: '0440'
+  # clear startup check on deps for included perun-core
+  vars:
+    perun_rpc_external_programs_dependencies: []
   notify: "restart perun_auditlogger"
 
 - name: "create perun-apps-config.yml for Auditlogger"

--- a/tasks/perun_ldapc.yml
+++ b/tasks/perun_ldapc.yml
@@ -24,6 +24,9 @@
     owner: root
     group: perunldc
     mode: 0440
+  # clear startup check on deps for included perun-core
+  vars:
+    perun_rpc_external_programs_dependencies: []
   notify: "restart perun_ldapc"
 
 - name: "create perun-apps-config.yml for LDAPc"


### PR DESCRIPTION
- Override default check of external dependencies on startup for perun_auditlogger and perun_ldapc since they are not actually used/required and are not present.