### PR TITLE
Allow customization of existing property in perun.properties

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -113,6 +113,7 @@ perun_rpc_group_sync_interval: 1
 perun_rpc_group_sync_timeout: 10
 perun_rpc_group_structure_sync_timeout: 10
 perun_rpc_group_maxConcurentGroupsToSynchronize: 10
+perun_rpc_group_structure_maxConcurrentGroupsStructuresToSynchronize: 10
 perun_rpc_powerusers: "perun"
 perun_rpc_db_initializator_enabled: yes
 perun_rpc_userInfoEndpoint_extSourceLogin: ""

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -30,6 +30,9 @@ perun.group.structure.synchronization.timeout={{ perun_rpc_group_structure_sync_
 # Limit on number of concurrently running synchronizations (default 10)
 perun.group.maxConcurentGroupsToSynchronize={{ perun_rpc_group_maxConcurentGroupsToSynchronize }}
 
+# Limit on number of concurrently running group structure synchronizations (default 10)
+perun.group.structure.maxConcurrentGroupsStructuresToSynchronize={{ perun_rpc_group_structure_maxConcurrentGroupsStructuresToSynchronize }}
+
 # Users who can do delegation
 perun.rpc.powerusers = {{ perun_rpc_powerusers }}
 


### PR DESCRIPTION
- Allow changing default value for "perun.group.structure. maxConcurrentGroupsStructuresToSynchronize" in perun.properties.