### PR TITLE
Allow extension of perun_rpc_dont_lookup_users variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,6 @@ perun_rpc_hostname: "{{ inventory_hostname }}"
 perun_rpc_hostname_aliases: []
 perun_rpc_admins:
   - perunDispatcher
-  - perunController
   - perunEngine
   - perunRegistrar
   - perunCabinet
@@ -57,7 +56,6 @@ perun_rpc_engine_principals:
   - perun-engine
 perun_rpc_dont_lookup_users:
   - perunDispatcher
-  - perunController
   - perunEngine
   - perunRegistrar
   - perunCabinet
@@ -66,6 +64,7 @@ perun_rpc_dont_lookup_users:
   - perunNotifications
   - perunRpc
   - perunSynchronizer
+perun_rpc_additional_dont_lookup_users: []
 perun_rpc_rt_url: ""
 perun_rpc_rt_defaultQueue: ""
 perun_rpc_rt_serviceuser_username: ""

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -16,7 +16,7 @@ perun.notification.principals = perunNotifications
 perun.rpc.principal = perunRpc
 
 # Do not lookup users for these logins
-perun.dont.lookup.users={{ perun_rpc_dont_lookup_users|join(', ') }}
+perun.dont.lookup.users={{ (perun_rpc_dont_lookup_users+perun_rpc_additional_dont_lookup_users)|join(', ') }}
 
 # Default group synchronization interval in fold of 5 minutes
 perun.group.synchronization.interval = {{ perun_rpc_group_sync_interval }}


### PR DESCRIPTION
- Introduce "perun_rpc_additional_dont_lookup_users" variable to allow extension of default list of principals for "perun.dont.lookup.users" property in perun.properties. Previously it was only possible to override this configuration, now values can be just added to the default list using this new config option.
- Removed "perunController" principal from default config since it's no longer used anywhere in the sources.