### PR TITLE
Allow setting custom SP config for main perun site

### DIFF
--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -212,6 +212,9 @@ ShibCompatValidUser on
   ##     Identity Consolidator    ####
   ####################################
 
+{% if perun_apache_consolidator_custom_sp is defined %}
+{{ perun_apache_consolidator_custom_sp }}
+{% else %}
   # SP endpoint
   <Location "/Consolidator.sso">
     AuthType shibboleth
@@ -219,11 +222,11 @@ ShibCompatValidUser on
     ShibRequestSetting applicationId consolidator
     Require shib-session
   </Location>
-
 {% if perun_apache_consolidator_forceAuthn %}
   <LocationMatch "^/Consolidator.sso/Login">
     ShibRequestSetting forceAuthn On
   </LocationMatch>
+{% endif %}
 {% endif %}
 
 {% if  perun_apache_consolidator_rewrite_rules is defined %}
@@ -295,24 +298,28 @@ ShibCompatValidUser on
     ShibRequestSetting applicationId {{ item.applicationId }}
     ShibRequestSetting requireSession 1
 {% if item.id is defined %}
-    ShibRequestSetting requireSessionWith {{  item.id }}
+    ShibRequestSetting requireSessionWith {{ item.id }}
 {% endif %}
 {% if item.entityID is defined %}
-    ShibRequestSetting entityID {{  item.entityID }}
+    ShibRequestSetting entityID {{ item.entityID }}
 {% endif %}
     Require shib-session
   </LocationMatch>
 
   <LocationMatch "^/{{ item.url }}-ic/">
     AuthType shibboleth
+{% if item.consolidatorApplicationId is defined %}
+    ShibRequestSetting applicationId {{ item.consolidatorApplicationId }}
+{% else %}
     ShibRequestSetting applicationId consolidator
+{% endif %}
     ShibRequestSetting requireSession 1
 {% if item.id is defined %}
-    ShibRequestSetting requireSessionWith {{  item.id }}
+    ShibRequestSetting requireSessionWith {{ item.id }}
 {% endif %}
     ShibRequestSetting forceAuthn On
 {% if item.entityID is defined %}
-    ShibRequestSetting entityID {{  item.entityID }}
+    ShibRequestSetting entityID {{ item.entityID }}
 {% endif %}
     Require shib-session
   </LocationMatch>


### PR DESCRIPTION
- If "perun_apache_consolidator_custom_sp" is defined, it replaces
  default SP config for perun default site (path to /Shibboleth.sso etc.).
  This logic can be used to create additional site (eg. signup-like) with
  same template, using different SP config.
- "perun_apache_fed_initiators" can now specify new property
  "consolidatorApplicationId" which will be used for consolidator
  prefixes (eg. /fed-ic/) as applicationId. This allows us to have
  multiple consolidator SPs in one config.