### PR TITLE
Removed /publications/ from apache headers regex

### DIFF
--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -105,9 +105,9 @@ ShibCompatValidUser on
   Header always set Permissions-Policy "accelerometer=(), autoplay=(), camera=(), geolocation=(), microphone=(), payment=()"
 
   # Disable browser caching for our html/rpc resources
-  Header always set Cache-Control "no-cache, no-store, max-age=0, must-revalidate" "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|ic|registrar|publications|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
-  Header always set Pragma no-cache "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|ic|registrar|publications|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
-  Header always set Expires 0 "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|ic|registrar|publications|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
+  Header always set Cache-Control "no-cache, no-store, max-age=0, must-revalidate" "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|ic|registrar|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
+  Header always set Pragma no-cache "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|ic|registrar|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
+  Header always set Expires 0 "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|ic|registrar|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
 
 {% if perun_rpc_cors_domains %}
   # CORS headers


### PR DESCRIPTION
- We do not have WUI app for publications, so it doesn't have to be a part of regex for Apache no-cache headers.