### PR TITLE
Allow setting authz filter for new GUI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -279,6 +279,8 @@ perun_ngui_admin_oauth_silent_redirect_uri: "https://{{ perun_ngui_admin_hostnam
 perun_ngui_admin_oauth_load_user_info: false
 perun_ngui_admin_oauth_scopes: "openid profile perun_api perun_admin offline_access"
 perun_ngui_admin_oauth_response_type: "code"
+perun_ngui_admin_oauth_filters:
+  default: ""
 perun_ngui_admin_proxy_logout: true
 perun_ngui_admin_supported_languages: ['en']
 perun_ngui_admin_member_profile_attributes_friendly_names: []
@@ -312,6 +314,7 @@ perun_ngui_profile_oauth_redirect_uri: "https://{{ perun_ngui_profile_hostname }
 perun_ngui_profile_oauth_scopes: "openid profile perun_api offline_access"
 perun_ngui_profile_oauth_response_type: "code"
 perun_ngui_profile_oauth_offline_access_consent_prompt: '{{ perun_ngui_oauth_offline_access_consent_prompt }}'
+perun_ngui_profile_oauth_filters: '{{ perun_ngui_admin_oauth_filters }}'
 perun_ngui_profile_proxy_logout: true
 perun_ngui_profile_password_namespace_attributes: []
 perun_ngui_profile_consolidator_url: "https://{{ perun_rpc_hostname }}/fed-ic/ic/"
@@ -442,6 +445,7 @@ perun_ngui_pwdreset_oauth_redirect_uri: "https://{{ perun_ngui_pwdreset_hostname
 perun_ngui_pwdreset_oauth_scopes: "openid profile perun_api offline_access"
 perun_ngui_pwdreset_oauth_response_type: "code"
 perun_ngui_pwdreset_oauth_offline_access_consent_prompt: '{{ perun_ngui_oauth_offline_access_consent_prompt }}'
+perun_ngui_pwdreset_oauth_filters: '{{ perun_ngui_admin_oauth_filters }}'
 perun_ngui_pwdreset_mfa: {}
 perun_ngui_pwdreset_password_help: '{{ perun_ngui_password_help }}'
 perun_ngui_pwdreset_password_help_cs: '{{ perun_ngui_password_help_cs }}'

--- a/templates/instance_configs/instanceConfig.json.j2
+++ b/templates/instance_configs/instanceConfig.json.j2
@@ -30,7 +30,8 @@
     "oauth_load_user_info": {{ perun_ngui_admin_oauth_load_user_info|bool|to_json }},
     "oauth_scopes": "{{ perun_ngui_admin_oauth_scopes }}",
     "oauth_response_type": "{{ perun_ngui_admin_oauth_response_type }}",
-    "oauth_offline_access_consent_prompt": {{ perun_ngui_oauth_offline_access_consent_prompt|bool|to_json }}
+    "oauth_offline_access_consent_prompt": {{ perun_ngui_oauth_offline_access_consent_prompt|bool|to_json }},
+    "filters": {{ perun_ngui_admin_oauth_filters|to_nice_json(indent=2,ensure_ascii=False)|indent(4) }}
   },
   "proxy_logout": {{ perun_ngui_admin_proxy_logout|bool|to_json }},
   "login_namespace_attributes": {{ perun_ngui_admin_login_namespace_attributes|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},

--- a/templates/instance_configs/profileInstanceConfig.json.j2
+++ b/templates/instance_configs/profileInstanceConfig.json.j2
@@ -20,7 +20,8 @@
     "oauth_redirect_uri": "{{ perun_ngui_profile_oauth_redirect_uri }}",
     "oauth_scopes": "{{ perun_ngui_profile_oauth_scopes }}",
     "oauth_response_type": "{{ perun_ngui_profile_oauth_response_type }}",
-    "oauth_offline_access_consent_prompt": {{ perun_ngui_profile_oauth_offline_access_consent_prompt|to_json }}
+    "oauth_offline_access_consent_prompt": {{ perun_ngui_profile_oauth_offline_access_consent_prompt|to_json }},
+    "filters": {{ perun_ngui_profile_oauth_filters|to_nice_json(indent=2,ensure_ascii=False)|indent(4) }}
   },
   "proxy_logout": {{ perun_ngui_profile_proxy_logout|bool|to_json }},
   "password_namespace_attributes": {{ perun_ngui_profile_password_namespace_attributes|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},

--- a/templates/instance_configs/pwdresetInstanceConfig.json.j2
+++ b/templates/instance_configs/pwdresetInstanceConfig.json.j2
@@ -12,14 +12,15 @@
   "auto_auth_redirect": {{ perun_ngui_pwdreset_auto_oauth_redirect|to_json }},
   "supported_languages": {{ perun_ngui_pwdreset_supported_languages|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "oidc_client" : {
-	"oauth_authority": "{{ perun_ngui_pwdreset_oauth_authority }}",
-	"oauth_callback": "{{ perun_ngui_pwdreset_oauth_callback }}",
-	"oauth_client_id": "{{ perun_ngui_pwdreset_client_id }}",
-	"oauth_post_logout_redirect_uri": "{{ perun_ngui_pwdreset_oauth_post_logout_redirect_uri }}",
-	"oauth_redirect_uri": "{{ perun_ngui_pwdreset_oauth_redirect_uri }}",
-	"oauth_scopes": "{{ perun_ngui_pwdreset_oauth_scopes }}",
-	"oauth_response_type": "{{ perun_ngui_pwdreset_oauth_response_type }}",
-	"oauth_offline_access_consent_prompt": {{ perun_ngui_pwdreset_oauth_offline_access_consent_prompt|to_json }}
+    "oauth_authority": "{{ perun_ngui_pwdreset_oauth_authority }}",
+    "oauth_callback": "{{ perun_ngui_pwdreset_oauth_callback }}",
+    "oauth_client_id": "{{ perun_ngui_pwdreset_client_id }}",
+    "oauth_post_logout_redirect_uri": "{{ perun_ngui_pwdreset_oauth_post_logout_redirect_uri }}",
+    "oauth_redirect_uri": "{{ perun_ngui_pwdreset_oauth_redirect_uri }}",
+    "oauth_scopes": "{{ perun_ngui_pwdreset_oauth_scopes }}",
+    "oauth_response_type": "{{ perun_ngui_pwdreset_oauth_response_type }}",
+    "oauth_offline_access_consent_prompt": {{ perun_ngui_pwdreset_oauth_offline_access_consent_prompt|to_json }},
+    "filters": {{ perun_ngui_pwdreset_oauth_filters|to_nice_json(indent=2,ensure_ascii=False)|indent(4) }}
   },
   "mfa": {{ perun_ngui_pwdreset_mfa|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
 {% if perun_ngui_pwdreset_warning_message %}


### PR DESCRIPTION
- Support for admin, profile and pwdreset config.
- By default we have only empty filter "".
- Filters for profile and pwdreset defaults to admin filter.
- Filters are picked and used by GUI based on URL param "idpFilter".