### PR TITLE
Forward cert variables to AJP on api-cert domain

### DIFF
--- a/templates/sites-enabled/perun-api-cert.conf.j2
+++ b/templates/sites-enabled/perun-api-cert.conf.j2
@@ -94,7 +94,7 @@
         ProxySet secret={{ perun_rpc_ajp_secret }}
     </Proxy>
 
-    RewriteRule ^/(.*)/rpc/(.*)$ ajp://{{ perun_rpc_container.container.Config.Hostname }}:8009/perun-rpc/$2 [P,QSA]
+    RewriteRule ^/(.*)/rpc/(.*)$ ajp://{{ perun_rpc_container.container.Config.Hostname }}:8009/perun-rpc/$2 [P,QSA,E=AJP_SSL_CLIENT_VERIFY:%{SSL:SSL_CLIENT_VERIFY},E=AJP_SSL_CLIENT_I_DN:%{SSL:SSL_CLIENT_I_DN},E=AJP_SSL_CLIENT_S_DN:%{SSL:SSL_CLIENT_S_DN},E=AJP_SSL_CLIENT_CERT:%{SSL:SSL_CLIENT_CERT}]
 
     ####################################
     ##     AuthN Methods            ####


### PR DESCRIPTION
- Updated template for cert-only API domain. We must include subject/issuer and other cert variables in AJP request to tomcat, otherwise user is not recognized.