### PR TITLE
Remove unused perun-cabinet.properties from perun_rpc

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -519,10 +519,6 @@ perun_registrar_backupTo: "{{ perun_email }}"
 perun_registrar_replyTo: ""
 perun_registrar_replyToName: ""
 
-# perun-cabinet.properties
-perun_cabinet_mu_login: ""
-perun_cabinet_mu_password: ""
-
 # LDAP
 perun_ldap_local: true
 perun_ldap_url: "ldap://perun-host:389"

--- a/tasks/perun_rpc.yml
+++ b/tasks/perun_rpc.yml
@@ -76,14 +76,11 @@
     mode: '0440'
   notify: "restart perun_rpc"
 
-- name: "create perun-cabinet.properties"
-  template:
-    src: perun-cabinet.properties.j2
-    dest: /etc/perun/rpc/perun-cabinet.properties
-    owner: root
-    group: perunrpc
-    mode: '0440'
-  notify: "restart perun_rpc"
+# TODO - remove after some time
+- name: "remove unused perun-cabinet.properties"
+  file:
+    path: '/etc/perun/rpc/perun-cabinet.properties'
+    state: absent
 
 - name: "create perun-registrar-lib.properties"
   template:

--- a/templates/perun-cabinet.properties.j2
+++ b/templates/perun-cabinet.properties.j2
@@ -1,5 +1,0 @@
-{{ ansible_managed | comment }}
-
-# MU prezentator login & password for Cabinet to import publications
-perun.cabinet.mu.login = {{ perun_cabinet_mu_login }}
-perun.cabinet.mu.password = {{ perun_cabinet_mu_password }}


### PR DESCRIPTION
- This config file is no longer used. It was used only for tests. Make sure it is removed from all deployments.