### PR TITLE
Enabled Certificate Revocation Lists checking

### DIFF
--- a/templates/sites-enabled/perun-api-cert.conf.j2
+++ b/templates/sites-enabled/perun-api-cert.conf.j2
@@ -64,6 +64,8 @@
     SSLVerifyDepth 5
     SSLVerifyClient optional
     SSLOptions +LegacyDNStringFormat
+	SSLCARevocationCheck chain
+	SSLCARevocationPath /etc/grid-security/certificates/
 
     LogLevel warn ssl:warn rewrite:warn
 

--- a/templates/sites-enabled/perun-cert.conf.j2
+++ b/templates/sites-enabled/perun-cert.conf.j2
@@ -79,6 +79,8 @@
     SSLVerifyDepth 5
     SSLVerifyClient optional
     SSLOptions +LegacyDNStringFormat
+	SSLCARevocationCheck chain
+	SSLCARevocationPath /etc/grid-security/certificates/
 
     LogLevel warn ssl:warn rewrite:warn
 

--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -76,6 +76,8 @@ ShibCompatValidUser on
   SSLVerifyDepth 5
   SSLVerifyClient optional
   SSLOptions +LegacyDNStringFormat
+  SSLCARevocationCheck chain
+  SSLCARevocationPath /etc/grid-security/certificates/
 {% endif %}
 
   # Increasing limits on HTTP headers. Connector packetSize in Tomcat must be set to bigger value than ProxyIOBufferSize here.


### PR DESCRIPTION
- CRLs were not checked so far, this change adds directives to check them.
- The service *fetch-crl-cron* must be installed and started for this to work.