### PR TITLE
Allow extending default-src rule of CSP on main perun site

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -635,6 +635,7 @@ perun_apache_oauth_introspection_url: https://login.example.org/oidc/introspecti
 perun_apache_oauth_introspection_cache_timeout_seconds: 300
 perun_apache_oauth_client_id: xxx-xxxx-xxx-xxx-x-x-x-x-xxxx
 perun_apache_oauth_client_secret: XXXXXXXXXXXXXXXXXXXXXXXXXXXX
+perun_apache_csp_default_src: ""
 perun_apache_csp_script_src: ""
 perun_apache_csp_frame_src: ""
 perun_apache_csp_style_src: ""

--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -97,7 +97,7 @@ ShibCompatValidUser on
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ {{ perun_apache_csp_script_src }} ; frame-src https://www.google.com/recaptcha/ {{ perun_apache_csp_frame_src }} ; style-src 'self' 'unsafe-inline' {{ perun_apache_csp_style_src }}; font-src 'self' {{ perun_apache_csp_font_src }} ; img-src 'self' data: {{ perun_apache_csp_img_src }} ; ; connect-src 'self' {{ perun_apache_csp_connect_src }}"
+  Header always set Content-Security-Policy "default-src 'self' {{ perun_apache_csp_default_src }} ; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ {{ perun_apache_csp_script_src }} ; frame-src https://www.google.com/recaptcha/ {{ perun_apache_csp_frame_src }} ; style-src 'self' 'unsafe-inline' {{ perun_apache_csp_style_src }}; font-src 'self' {{ perun_apache_csp_font_src }} ; img-src 'self' data: {{ perun_apache_csp_img_src }} ; ; connect-src 'self' {{ perun_apache_csp_connect_src }}"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/


### PR DESCRIPTION
- Set "perun_apache_csp_default_src" to change the value, by default empty.