### PR TITLE
fix: 🐛 joining of registrar.hideProxy values

### DIFF
--- a/templates/perun-web-gui.properties.j2
+++ b/templates/perun-web-gui.properties.j2
@@ -122,7 +122,7 @@ registrar.skipSummaryFor={{ perun_oldgui_registrar_skipSummaryFor|join(', ') }}
 registrar.findSimilarUsers.disabled={{ perun_oldgui_registrar_findSimilarUsers_disabled }}
 
 # List of proxies from which we hide identities during VO/Group registration.
-registrar.hideProxy={{ perun_oldgui_registrar_hide_proxy|join(', ') }}
+registrar.hideProxy={{ perun_oldgui_registrar_hide_proxy|join(',') }}
 
 ### User Profile ###
 


### PR DESCRIPTION
Remove space from the join string. Caused properties to be ignored. Properly, values of this setting need to be separated just by comma.