### PR TITLE
Hold all postgresql packages after clean perun install

### DIFF
--- a/tasks/postgres.yml
+++ b/tasks/postgres.yml
@@ -23,3 +23,19 @@
     name: pv
     state: present
 
+- name: "make list of packages for holding"
+  set_fact:
+    psql_packages:
+      - "postgresql-{{ perun_postgresql_version }}"
+      - "postgresql-client-{{ perun_postgresql_version }}"
+      - "postgresql-{{ perun_postgresql_version }}-repack"
+      - postgresql-client-common
+      - postgresql-common
+- debug:
+    var: psql_packages
+
+- name: "Hold postgresql packages from upgrading"
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop: "{{ psql_packages }}"


### PR DESCRIPTION
- Manual upgrade using playbook_upgrade_postgres_minor.yml holds them correctly, but it was missing in playbook_perun.yml (postgresql.yml tasks).