### PR TITLE
Copy check_mk config from each instance files by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -853,6 +853,9 @@ perun_firewall_docker_rules:
       - { ipv6: "2001:718:ff05:acb::/64", comment: "portainer from CESNET eduVPN IPv6" }
       - { ipv6: "2001:718:ff05:acc::/64", comment: "portainer from CESNET eduVPN IPv6" }
 
+# config files for probes from Metacentrum monitoring
+perun_monitoring_check_mk_config: "{{ perun_instance_hostname }}/check_mk/"
+
 # debian repos to use for automatic updates
 perun_unattended_upgrades_origin_patterns: |2
             "origin=Debian,codename=${distro_codename}";

--- a/tasks/os_setup.yml
+++ b/tasks/os_setup.yml
@@ -8,6 +8,8 @@
 - name: "set up monitoring by MetaCentrum's Nagios"
   import_role:
     name: cesnet.metacentrum_monitoring
+  vars:
+    monitoring_check_mk_config: "{{ perun_monitoring_check_mk_config }}"
 
 - name: "set up unattended upgrades"
   import_role:


### PR DESCRIPTION
- Requires cesnet.metacentrum_monitoring role version v4.1.0
- Automatically copy files from perun_instance/check_mk/*.cfg to /etc/check_mk/ for metacentrum monitoring to notice.