### PR TITLE
Removed option to disable vo creation button in old GUI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -177,7 +177,6 @@ perun_oldgui_profile_personal_showAttributes:
   - urn:perun:user:attribute-def:def:preferredMail
 perun_oldgui_profile_hidePages:  [ 'settings' ]
 perun_oldgui_profile_settings_hidePages: [ 'sshkeys', 'dataquotas']
-perun_oldgui_disableCreateVo: 'false'
 perun_oldgui_rt_defaultQueue: "perun"
 perun_oldgui_rt_defaultMail: "perun@cesnet.cz"
 perun_oldgui_report_email_address: "{{ perun_email }}"

--- a/templates/perun-web-gui.properties.j2
+++ b/templates/perun-web-gui.properties.j2
@@ -13,7 +13,6 @@ namespacesForPreferredGroupNames={{ perun_oldgui_namespacesForPreferredGroupName
 vosToSkipCaptchaFor={{ perun_oldgui_vosToSkipCaptchaFor|join(',') }}
 nativeLanguage={{ perun_oldgui_nativeLanguage }}
 getIdentityConsolidatorUrl={{ perun_oldgui_getIdentityConsolidatorUrl }}
-disableCreateVo={{ perun_oldgui_disableCreateVo }}
 # GDPR agreement logic for admins in Perun. Any admin is required to agree with the last version of the text.
 # His approvals are stored in "urn:perun:user:attribute-def:def:gdprAdminApprovedVersions".
 # Relevant to CESNET instance only


### PR DESCRIPTION
- Since perun v44.0.0 VO creation in old GUI is handled by new VOCREATOR role, by default nobody can create VO (except for perun admin).
- Removed config "disableCreateVo" from perun-web-gui.properties.
- Removed config "perun_oldgui_disableCreateVo" from ansible role (default was false).