### PR TITLE
Added new config options in perun.properties required by v44.1.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -134,6 +134,16 @@ perun_rpc_external_programs_dependencies:
 perun_rpc_auditlog_read_limit: 10000
 perun_rpc_archive_spool: no
 perun_rpc_logback_ultimate_logger_level: error
+# Default personal data change on profile (allow changing preferred email / requires verification)
+perun_rpc_personal_enable_linked_name: no
+perun_rpc_personal_enable_custom_name: no
+perun_rpc_personal_custom_name_requires_approve: no
+perun_rpc_personal_enable_linked_organization: no
+perun_rpc_personal_enable_custom_organization: no
+perun_rpc_personal_custom_organization_requires_approve: no
+perun_rpc_personal_enable_linked_email: no
+perun_rpc_personal_enable_custom_email: yes
+perun_rpc_personal_custom_email_requires_approve: yes
 
 # TODO - enable when we ditch old admin gui and enable step-up for MFA
 perun_rpc_app_allowed_roles: []

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -243,3 +243,16 @@ perun.auditlogReadLimit={{ perun_rpc_auditlog_read_limit }}
 
 # Set to "true" to archive data generated during each run of service provisioning
 perun.archiveSpool={{ perun_rpc_archive_spool|bool|to_json }}
+
+# Personal data change switchers
+perun.enableLinkedName={{ perun_rpc_personal_enable_linked_name|bool|to_json }}
+perun.enableCustomName={{ perun_rpc_personal_enable_custom_name|bool|to_json }}
+perun.customNameRequiresApprove={{ perun_rpc_personal_custom_name_requires_approve|bool|to_json }}
+
+perun.enableLinkedOrganization={{ perun_rpc_personal_enable_linked_organization|bool|to_json }}
+perun.enableCustomOrganization={{ perun_rpc_personal_enable_custom_organization|bool|to_json }}
+perun.customOrganizationRequiresApprove={{ perun_rpc_personal_custom_organization_requires_approve|bool|to_json }}
+
+perun.enableLinkedEmail={{ perun_rpc_personal_enable_linked_email|bool|to_json }}
+perun.enableCustomEmail={{ perun_rpc_personal_enable_custom_email|bool|to_json }}
+perun.customEmailRequiresVerification={{ perun_rpc_personal_custom_email_requires_approve|bool|to_json }}


### PR DESCRIPTION
New config options required by perun v44.1.0 can be configured using following vars and have following defaults. They are used to configure handling of personal data on profile (allow changes to name, organization and email and whether it requires approval).

- perun_rpc_personal_enable_linked_name: no
- perun_rpc_personal_enable_custom_name: no
- perun_rpc_personal_custom_name_requires_approve: no
- perun_rpc_personal_enable_linked_organization: no
- perun_rpc_personal_enable_custom_organization: no
- perun_rpc_personal_custom_organization_requires_approve: no
- perun_rpc_personal_enable_linked_email: no
- perun_rpc_personal_enable_custom_email: yes
- perun_rpc_personal_custom_email_requires_approve: yes