### PR TITLE
Support other_apps_custom in NGUI configuration since v18.6.0 (perun v47.0.0)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -312,6 +312,7 @@ perun_ngui_admin_password_help: '{{ perun_ngui_password_help }}'
 perun_ngui_admin_other_apps:
   en:
     profile: "Profile"
+perun_ngui_admin_other_apps_custom:
 
 #new GUI Profile
 perun_ngui_profile_enabled: no
@@ -368,6 +369,7 @@ perun_ngui_profile_other_apps:
     admin: "IAM Administration"
   cs:
     admin: "Správa IAM"
+perun_ngui_profile_other_apps_custom:
 perun_ngui_profile_link_to_admin_gui_by_roles: [
     "PERUNADMIN",
     "PERUNOBSERVER",
@@ -405,6 +407,7 @@ perun_ngui_consolidator_document_title: "Consolidator"
 perun_ngui_consolidator_other_apps:
   en:
     profile: "Profile"
+perun_ngui_consolidator_other_apps_custom:
 perun_ngui_consolidator_client_id: "xxx-xxxx-xxxx-xxx-xx-xxx"
 perun_ngui_consolidator_oauth_authority: '{{ perun_ngui_oauth_authority }}'
 perun_ngui_consolidator_oauth_csp_url: '{{ perun_ngui_consolidator_oauth_authority }}'
@@ -508,6 +511,7 @@ perun_ngui_publications_other_apps:
   en:
     admin: "IAM Administration"
     profile: "Profile"
+perun_ngui_publications_other_apps_custom:
 perun_ngui_publications_link_to_admin_gui_by_roles: [
   "PERUNADMIN",
   "PERUNOBSERVER",

--- a/templates/instance_configs/consolidatorInstanceConfig.json.j2
+++ b/templates/instance_configs/consolidatorInstanceConfig.json.j2
@@ -20,6 +20,7 @@
   "proxy_logout": {{ perun_ngui_consolidator_proxy_logout|bool|to_json }},
   "document_title": "{{ perun_ngui_consolidator_document_title }}",
   "other_apps": {{ perun_ngui_consolidator_other_apps|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
+  "other_apps_custom": {{ perun_ngui_consolidator_other_apps_custom|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "link_to_admin_gui_by_roles": {{ perun_ngui_publications_link_to_admin_gui_by_roles|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "instance_favicon": {{ perun_ngui_consolidator_instance_favicon|to_json }},
   "path_to_idp_provider_userinfo": {{ perun_ngui_consolidator_path_to_idp_provider_userinfo|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},

--- a/templates/instance_configs/instanceConfig.json.j2
+++ b/templates/instance_configs/instanceConfig.json.j2
@@ -49,6 +49,7 @@
   "footer": {{ perun_ngui_footer|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "log_out_enabled": {{ perun_ngui_admin_log_out_enabled|bool|to_json }},
   "other_apps": {{ perun_ngui_admin_other_apps|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
+  "other_apps_custom": {{ perun_ngui_admin_other_apps_custom|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "logo": {{ perun_ngui_logo|to_json }},
   "theme": {{ perun_ngui_theme|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "brandings": {{ perun_ngui_admin_brandings|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},

--- a/templates/instance_configs/profileInstanceConfig.json.j2
+++ b/templates/instance_configs/profileInstanceConfig.json.j2
@@ -48,6 +48,7 @@
   "warning_message": "{{ perun_ngui_profile_warning_message }}",
 {% endif %}
   "other_apps": {{ perun_ngui_profile_other_apps|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
+  "other_apps_custom": {{ perun_ngui_profile_other_apps_custom|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "logo": {{ perun_ngui_profile_logo|to_json }},
   "brandings": {{ perun_ngui_profile_brandings|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "use_new_consolidator": {{ perun_ngui_profile_use_new_consolidator|to_json }},

--- a/templates/instance_configs/publicationsInstanceConfig.json.j2
+++ b/templates/instance_configs/publicationsInstanceConfig.json.j2
@@ -35,6 +35,7 @@
   "header_label_cs": "{{ perun_ngui_publications_header_label_cs }}",
   "export_limit": {{ perun_ngui_table_export_limit }},
   "other_apps": {{ perun_ngui_publications_other_apps|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
+  "other_apps_custom": {{ perun_ngui_publications_other_apps_custom|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "footer": {{ perun_ngui_publications_footer|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "theme": {{ perun_ngui_publications_theme|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "brandings": {{ perun_ngui_publications_brandings|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }}


### PR DESCRIPTION
- Shortcuts to other "apps" in a header of perun NGUI apps can now contain also links to external websites/apps.
- Supported in admin, profile, publications and consolidator apps by variables named like:
  "perun_ngui_[app]_other_apps_custom".
- Expected format for config value is same as standard other_apps, but instead of fixed "keys"
  representing apps we can use custom URLs.