### PR TITLE
Add perun.globalSearchLimit property to perun.properties

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -133,6 +133,7 @@ perun_rpc_external_programs_dependencies:
   - openssl
 perun_rpc_auditlog_read_limit: 10000
 perun_rpc_archive_spool: no
+perun_rpc_global_search_limit: 4
 perun_rpc_logback_ultimate_logger_level: error
 # Default personal data change on profile (allow changing preferred email / requires verification)
 perun_rpc_personal_enable_linked_name: no

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -244,6 +244,9 @@ perun.auditlogReadLimit={{ perun_rpc_auditlog_read_limit }}
 # Set to "true" to archive data generated during each run of service provisioning
 perun.archiveSpool={{ perun_rpc_archive_spool|bool|to_json }}
 
+# Max number of results for all entities in global search from NGUI
+perun.globalSearchLimit={{ perun_rpc_global_search_limit }}
+
 # Personal data change switchers
 perun.enableLinkedName={{ perun_rpc_personal_enable_linked_name|bool|to_json }}
 perun.enableCustomName={{ perun_rpc_personal_enable_custom_name|bool|to_json }}


### PR DESCRIPTION
- New property perun.globalSearchLimit can limit number of results for all entities in global search in GUI.
- Default is 4 results for each entity.
- Value is configurable by ansible var "perun_rpc_global_search_limit".
- Property has been added for perun v47.1.0.