### PR TITLE
Allow enablement of global search in Admin GUI.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -261,6 +261,8 @@ perun_ngui_logo: "😀"
 perun_ngui_theme: {}
 perun_ngui_mfa: {}
 perun_ngui_table_export_limit: 1000
+# set to "yes" and configure "globalSearch_String_policy" policy on backend to display global search to proper roles
+perun_ngui_display_search: no
 
 # shared password strength hints for new GUI
 perun_ngui_password_help:

--- a/templates/instance_configs/instanceConfig.json.j2
+++ b/templates/instance_configs/instanceConfig.json.j2
@@ -55,5 +55,6 @@
   "brandings": {{ perun_ngui_admin_brandings|to_nice_json(indent=2,ensure_ascii=False)|indent(2) }},
   "user_deletion_forced": {{ perun_ngui_admin_user_deletion_forced|bool|to_json }},
   "enforce_consents": {{ perun_ngui_admin_enforce_consents|bool|to_json }},
-  "export_limit": {{ perun_ngui_table_export_limit }}
+  "export_limit": {{ perun_ngui_table_export_limit }},
+  "display_search": {{ perun_ngui_display_search|bool|to_json }}
 }


### PR DESCRIPTION
- Add "display_search" property to Admin GUI instance config.
- It can be configured by "perun_ngui_display_search" ansible property, default is false.
- Enabling this shows global search input in Admin GUI header. To define who is able to perform the search (and see the input) configure "globalSearch_String_policy" policy for API backend method.