### PR TITLE
Added new config options for perun-dispatcher.properties

### DIFF
--- a/templates/perun-dispatcher.properties.j2
+++ b/templates/perun-dispatcher.properties.j2
@@ -22,3 +22,9 @@ dispatcher.task.delay.count={{ perun_dispatcher_task_delay_count }}
 {% if perun_dispatcher_propagation_timeout is defined %}
 dispatcher.task.delay.timeout={{ perun_dispatcher_propagation_timeout }}
 {% endif %}
+{% if perun_dispatcher_task_poll_wait is defined %}
+dispatcher.task.poll.wait={{ perun_dispatcher_task_poll_wait }}
+{% endif %}
+{% if perun_dispatcher_task_reschedule is defined %}
+dispatcher.task.reschedule={{ perun_dispatcher_task_reschedule }}
+{% endif %}


### PR DESCRIPTION
- "perun_dispatcher_task_poll_wait" ansible var can be used to configure timeout for waiting tasks queue (time until we re-check forced tasks).
- "perun_dispatcher_task_reschedule" ansible var can be used to configure timeout after which we run propagation maintainer thread checking for done tasks with midified source data or error/stuck tasks.

Both vars have no default in ansible and are not used until defined in your group/host vars. In Perun default timeout for both is 10000 ms.