### PR TITLE
Support customization of authnContextClassRef in consolidator

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -196,6 +196,7 @@ perun_oldgui_fedAuthz: [ 'fed' ]
 perun_oldgui_supportedPasswordNamespaces: ''
 perun_oldgui_wayf_spLogoutUrl: "/Consolidator.sso/Logout"
 perun_oldgui_wayf_spLoginUrl: "/Consolidator.sso/Login"
+perun_oldgui_wayf_authnContextClassRef: "urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified%20urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
 perun_oldgui_namespacesForPreferredGroupNames: []
 perun_oldgui_vosToSkipCaptchaFor: []
 perun_oldgui_perunInstanceName: "{{ perun_rpc_instance_name }}"

--- a/templates/perun-web-gui.properties.j2
+++ b/templates/perun-web-gui.properties.j2
@@ -94,6 +94,7 @@ privacyPolicyLink={{ perun_oldgui_privacyPolicyLink }}
 wayf.cert.hosts={{ perun_oldgui_cert_hosts|join(',') }}
 wayf.spLogoutUrl={{ perun_oldgui_wayf_spLogoutUrl }}
 wayf.spLoginUrl={{ perun_oldgui_wayf_spLoginUrl }}
+wayf.authnContextClassRef={{ perun_oldgui_wayf_authnContextClassRef }}
 
 {% if perun_oldgui_wayf_idpTranslations is defined %}
 # custom IdP translations like: scope or entityID|name#scope or entityID|name#...


### PR DESCRIPTION
- "wayf.authnContextClassRef" property has been added to "perun-web-gui.properties" templates.
- It allows to configure default authn context class ref URL param for requests from registrar and consolidator in order to join identities.
- Added "perun_oldgui_wayf_authnContextClassRef" ansible var to configure this property which can be set to empty, but defaults to backward compatible value.