### PR TITLE
Install Metacentrum monitoring only when needed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -889,7 +889,8 @@ perun_firewall_docker_rules:
       - { ipv6: "2001:718:ff05:acb::/64", comment: "portainer from CESNET eduVPN IPv6" }
       - { ipv6: "2001:718:ff05:acc::/64", comment: "portainer from CESNET eduVPN IPv6" }
 
-# config files for probes from Metacentrum monitoring
+# Enabled Metacentrum monitoring and include config files for probes
+perun_metacentrum_monitoring: yes
 perun_monitoring_check_mk_config: "{{ perun_instance_hostname }}/check_mk/"
 
 # debian repos to use for automatic updates

--- a/tasks/os_setup.yml
+++ b/tasks/os_setup.yml
@@ -6,10 +6,16 @@
     name: cesnet.ntp
 
 - name: "set up monitoring by MetaCentrum's Nagios"
-  import_role:
+  include_role:
     name: cesnet.metacentrum_monitoring
+    apply:
+      tags:
+        - metacentrum_monitoring
+  when: perun_metacentrum_monitoring
   vars:
     monitoring_check_mk_config: "{{ perun_monitoring_check_mk_config }}"
+  tags:
+    - metacentrum_monitoring
 
 - name: "set up unattended upgrades"
   import_role:


### PR DESCRIPTION
- Previously role cesnet.metacentrum_monitoring has been imported into the cesnet.perun_docker_server role and thus monitoring has been setup on all perun instances.
- This change makes installation of Metacentrum's monitoring optional (installed by default for backward compatibility). You can disable it by setting "perun_metacentrum_monitoring" variable to false or no.