### PR TITLE
Enable OCSP stapling only when requested

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -625,6 +625,9 @@ perun_auditlogger_enabled: "{{ perun_remote_logging_enabled }}"
 # Apache #
 ##########
 
+# Whether to include OCSP stapling support
+perun_apache_ocsp_stapling: no
+
 # whether to set maintenance mode
 perun_apache_in_maintenance: no
 # whether to enable redirect from / to /{{ perun_apache_gui_default_auth }}/gui/

--- a/tasks/perun_apache.yml
+++ b/tasks/perun_apache.yml
@@ -342,6 +342,26 @@
   when: perun_apache_custom_vars is defined and perun_apache_custom_vars
   notify: "restart perun_apache"
 
+- name: "create apache_stapling.conf"
+  when: perun_apache_ocsp_stapling
+  copy:
+    dest: /etc/perun/apache/apache_stapling.conf
+    mode: '0644'
+    content: |2
+      # OCSP Stapling
+      SSLUseStapling          on
+      SSLStaplingResponderTimeout 5
+      SSLStaplingReturnResponderErrors off
+      SSLStaplingCache        shmcb:${APACHE_RUN_DIR}/ocsp(32768)
+  notify: "restart perun_apache"
+
+- name: "remove apache_stapling.conf"
+  when: not perun_apache_ocsp_stapling
+  file:
+    path: /etc/perun/apache/apache_stapling.conf
+    state: absent
+  notify: "restart perun_apache"
+
 - name: "create additional files for Shibboleth"
   copy:
     src: "{{ item }}"


### PR DESCRIPTION
- LetsEncrypt certs no longer have OCSP URLs so there is no reason to keep this Apache config enabled by default (it is a part of provided docker image!).
- OCSP stapling can be be now enabled by setting "perun_apache_ocsp_stapling" variable to "yes" (default is "no").
- In order for Apache to respect this option you need to use newer docker images with latest Perun where file "/etc/perun/apache/apache_stapling.conf" is optionaly included in Apache config.

  => Next perun release will disable OCSP stapling unless you re-enable it with the config mentioned above.