### PR TITLE
Make journald config template configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -934,3 +934,16 @@ perun_ldap_users:
   - user: proxy
     password: "{{ perun_ldap_proxy_password }}"
     description: "user for IdP Proxy"
+
+# variable "log_disk" is determined from /var/log volume by perun_journald.yml tasks before setting this template
+perun_journald_config: |
+  # see "man 5 journald.conf" for documentation of these directives
+  [Journal]
+  # use max 30% of disk
+  SystemMaxUse={{ (log_disk.size_total * 0.3 / 1073741824) | int }}G
+  # keep free at least 20% of disk
+  SystemKeepFree={{ (log_disk.size_total * 0.2 / 1073741824) | int }}G
+  # controls how large individual journal files in /var/log/journal may grow at most
+  SystemMaxFileSize=1G
+  # controls how many individual journal files to keep at most
+  SystemMaxFiles={{ (log_disk.size_total * 0.3 / 1073741824) | int }}

--- a/tasks/perun_journald.yml
+++ b/tasks/perun_journald.yml
@@ -18,17 +18,7 @@
 - name: "configure journald in /etc/systemd/journald.conf.d/perun.conf"
   copy:
     dest: /etc/systemd/journald.conf.d/perun.conf
-    content: |
-      # see "man 5 journald.conf" for documentation of these directives
-      [Journal]
-      # use max 30% of disk
-      SystemMaxUse={{ (log_disk.size_total * 0.3 / 1073741824) | int }}G
-      # keep free at least 20% of disk
-      SystemKeepFree={{ (log_disk.size_total * 0.2 / 1073741824) | int }}G
-      # controls how large individual journal files in /var/log/journal may grow at most
-      SystemMaxFileSize=1G
-      # controls how many individual journal files to keep at most
-      SystemMaxFiles={{ (log_disk.size_total * 0.3 / 1073741824) | int }}
+    content: "{{ perun_journald_config }}"
   register: perunjourconf
 
 - name: "reload journald configuration"


### PR DESCRIPTION
- We had fixed journald template with limits depending on size of the /var/log/ volume.
- Now we can redefine whole template by setting content to "perun_journald_config" var.