### PR TITLE
Support passing custom template file for remote logging

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -617,6 +617,7 @@ perun_remote_logging_port: 514
 perun_remote_logging_conf: remotelog
 perun_remote_logging_filter: ""
 perun_remote_logging_enable_disk_buffer: yes
+perun_remote_logging_template: remote_logging.j2
 
 # Auditlogger - by default enabled on instances logging remotely
 perun_auditlogger_enabled: "{{ perun_remote_logging_enabled }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,6 +78,7 @@
     remote_logging_conf: "{{ perun_remote_logging_conf }}"
     remote_logging_filter: "{{ perun_remote_logging_filter }}"
     remote_logging_enable_disk_buffer: "{{ perun_remote_logging_enable_disk_buffer }}"
+    remote_logging_template: "{{ perun_remote_logging_template }}"
 
 - name: "creation of users perun, peruneng, etc."
   import_tasks: perun_users.yml


### PR DESCRIPTION
- Set "remote_logging_template" when using cesnet.remote_logging from "perun_remote_logging_template" varaible defaulting to "remote_logging.j2" which is present within the role.
- You can change template file by setting a different filename (path) in the instance vars.
- Requires cesnet.remote_logging version v1.8