### PR TITLE
Remove support for OCSP stapling in apache config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -652,9 +652,6 @@ perun_auditlogger_enabled: "{{ perun_remote_logging_enabled }}"
 # Apache #
 ##########
 
-# Whether to include OCSP stapling support
-perun_apache_ocsp_stapling: no
-
 # whether to set maintenance mode
 perun_apache_in_maintenance: no
 # whether to enable redirect from / to /{{ perun_apache_gui_default_auth }}/gui/

--- a/tasks/perun_apache.yml
+++ b/tasks/perun_apache.yml
@@ -376,26 +376,6 @@
   when: perun_apache_custom_vars is defined and perun_apache_custom_vars | length > 0
   notify: "restart perun_apache"
 
-- name: "create apache_stapling.conf"
-  when: perun_apache_ocsp_stapling
-  copy:
-    dest: /etc/perun/apache/apache_stapling.conf
-    mode: '0644'
-    content: |2
-      # OCSP Stapling
-      SSLUseStapling          on
-      SSLStaplingResponderTimeout 5
-      SSLStaplingReturnResponderErrors off
-      SSLStaplingCache        shmcb:${APACHE_RUN_DIR}/ocsp(32768)
-  notify: "restart perun_apache"
-
-- name: "remove apache_stapling.conf"
-  when: not perun_apache_ocsp_stapling
-  file:
-    path: /etc/perun/apache/apache_stapling.conf
-    state: absent
-  notify: "restart perun_apache"
-
 - name: "create additional files for Shibboleth"
   copy:
     src: "{{ item }}"


### PR DESCRIPTION
- It has been unused (disabled by default).
- It is not really required by browsers.
- You can still enable it by adding necessary directives in your apache_custom_vars.conf.