### PR TITLE
Require TLS 1.3 on postgres port 5432 for external connections

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -788,6 +788,7 @@ perun_root_email_address: makub@ics.muni.cz
 perun_postgresql_settings:
   max_connections: 200
   max_pred_locks_per_transaction: 128
+  ssl_min_protocol_version: 'TLSv1.3'
 
 # sendmail directives to be added to sendmail.mc
 perun_sendmail_config: ""


### PR DESCRIPTION
- Set minimum TLS version to 1.3 (previously TLS 1.2+).
- Aplicable only for external connections from our VPN as by default postgres is available only locally and without ssl/tls.