### PR TITLE
Install sendmail by default when importing cesnet.unattended_upgrades role

### DIFF
--- a/tasks/os_setup.yml
+++ b/tasks/os_setup.yml
@@ -25,8 +25,8 @@
     unattended_upgrades_blacklist: "{{ perun_unattended_upgrades_blacklist }}"
     unattended_upgrades_automatic_reboot: "{{ perun_unattended_upgrades_automatic_reboot }}"
     root_email_address: "{{ perun_root_email_address }}"
-    unattended_upgrades_mta_package: "msmtp-mta"
-    unattended_upgrades_mail_package: "bsd-mailx"
+    unattended_upgrades_mta_package: "{{ perun_smtp_use_msmtp | ternary('msmtp-mta', 'sendmail') }}"
+    unattended_upgrades_mail_package: "{{ perun_smtp_use_msmtp | ternary('bsd-mailx', 'mailutils') }}"
 
 - name: "set up Yubikeys"
   import_role:


### PR DESCRIPTION
- Role itself defaults to sendmail, but we used to set msmtp-mta directly without considering instance preferences. So for instances with sendmail it resulted in installing msmtp-mta first and replacing it with sendmail later during the clean install.
- Now we respect "perun_smtp_use_msmtp" var, so it defaults to using sendmail and then it installs only sendmail. For instances which opt-in to use msmtp it installs only msmtp-mta.

  NOTE: There is still difference. When using sendmail, there is no default config (relay), when using msmtp CESNET relay is the default.