### PR TITLE
Require TLS 1.3 on LDAP port 636 with Debian 13

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -987,6 +987,9 @@ perun_ldap_users:
     password: "{{ perun_ldap_proxy_password }}"
     description: "user for IdP Proxy"
 
+# Require TLS 1.3 (works only on Debian 13 hosts)
+perun_ldap_tls_1_3_require: yes
+
 # variable "log_disk" is determined from /var/log volume by perun_journald.yml tasks before setting this template
 perun_journald_config: |
   # see "man 5 journald.conf" for documentation of these directives

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -225,6 +225,7 @@
     ldap_users: "{{ perun_ldap_users }}"
     ldap_tls_cipher_suite: "{{ 'SECURE192:-VERS-ALL:+VERS-TLS1.2:+VERS-TLS1.3' if perun_use_certbot_certificates else 'SECURE128:+SECURE192:-VERS-ALL:+VERS-TLS1.2:+VERS-TLS1.3:-AES-256-CBC:-AES-192-CBC:-AES-128-CBC:-3DES-CBC:-DES-CBC' }}"
     ldap_log_level: "{{ perun_ldap_log_level }}"
+    ldap_tls_1_3_require: "{{ perun_ldap_tls_1_3_require }}"
   tags:
     - perun_ldap
 


### PR DESCRIPTION
- Require TLS 1.3 on LDAP port 636 when installing Perun on Debian 13.
- Instances with older Debian are not affected by the new setting.
- You can disable it by setting "perun_ldap_tls_1_3_require" to "no".