### PR TITLE
Support deploying perun_cli_python

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ perun_apache_container_version: latest
 perun_ldapc_container_version: "{{ perun_rpc_container_version }}"
 perun_auditlogger_container_version: "{{ perun_rpc_container_version }}"
 perun_cli_container_version: "{{ perun_rpc_container_version }}"
+perun_cli_python_container_version: latest
 
 # used only for first database initialization
 perun_rpc_git_version: "{{ perun_rpc_container_version }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -373,7 +373,6 @@
   import_tasks: perun_syslog_containers.yml
   tags: perun_syslog
 
-
 - name: "site-specific tasks after perun config"
   when: perun_site_specific_tasks_after is defined
   include_tasks:

--- a/tasks/perun_cli.yml
+++ b/tasks/perun_cli.yml
@@ -7,6 +7,22 @@
     group: perun
     mode: '0440'
 
+- name: "create /etc/perun/perun-cli-python-env"
+  template:
+    src: perun-cli-python-env.j2
+    dest: /etc/perun/perun-cli-python-env
+    owner: perun
+    group: perun
+    mode: '0440'
+
+- name: "create /etc/perun/perun-cli-python-instances.json"
+  template:
+    src: perun-cli-python-instances.j2
+    dest: /etc/perun/perun-cli-python-instances.json
+    owner: perun
+    group: perun
+    mode: '0440'
+
 - name: "create /usr/local/bin/perun-cli"
   copy:
     dest: /usr/local/bin/perun-cli
@@ -43,12 +59,52 @@
         --env-file /etc/perun/perun-cli-env --entrypoint="" ${PERUN_DOCKER_OPTS} \
         {{ perun_container_registry }}/perun_cli_perl:{{ perun_cli_container_version }} "$@"
 
+- name: "create /usr/local/bin/perun-cli-python"
+  copy:
+    dest: /usr/local/bin/perun-cli-python
+    owner: perun
+    group: perun
+    mode: '0550'
+    content: |
+      #!/bin/bash
+      # runs an interactive container with current working dir and all arguments are passed to "bash -c " as a single long string
+      if [[ -z $* ]] ; then ARGS="bash" ; else ARGS="$*" ; fi
+      docker run -it --rm --name cli_python_$$ --hostname cli_python_$$ \
+        --network host \
+        --volume /home/perun:/home/perun \
+        --mount type=bind,source=/etc/perun/perun-cli-python-instances.json,target=/opt/perun-cli/instances.json \
+      {% for host, ip in perun_containers_etc_hosts.items() %}
+        --add-host {{ host }}:{{ ip }} \
+      {% endfor %}
+        --env-file /etc/perun/perun-cli-python-env -w $PWD ${PERUN_DOCKER_OPTS} \
+        {{ perun_container_registry }}/perun_cli_python:{{ perun_cli_python_container_version }} "$ARGS"
+
+- name: "create /usr/local/bin/perun-script-cli-python for scripts"
+  copy:
+    dest: /usr/local/bin/perun-script-cli-python
+    owner: perun
+    group: perun
+    mode: '0550'
+    content: |
+      #!/bin/bash
+      # runs non-interactive container with working dir /home/perun and arguments are passed as an array to exec
+      docker run --rm --name script_cli_python_$$ --volume /home/perun:/home/perun \
+        --network host \
+        --mount type=bind,source=/etc/perun/perun-cli-python-instances.json,target=/opt/perun-cli/instances.json \
+      {% for host, ip in perun_containers_etc_hosts.items() %}
+        --add-host {{ host }}:{{ ip }} \
+      {% endfor %}
+        --env-file /etc/perun/perun-cli-python-env --entrypoint="" ${PERUN_DOCKER_OPTS} \
+        {{ perun_container_registry }}/perun_cli_python:{{ perun_cli_python_container_version }} "$@"
+
 - name: "prune unused docker images other than CLI"
   docker_prune:
     images: yes
     images_filters:
       dangling: false
-      label!: org.perun-aai.cli
+      label!:
+        - org.perun-aai.cli
+        - org.perun-aai.cli-python
   register: pruned
 
 - name: "pruned"
@@ -61,7 +117,13 @@
     source: pull
     force_source: true
     state: present
-  register: perun_cli_image
+
+- name: "preload image for perun_cli_python"
+  docker_image:
+    name: "{{ perun_container_registry }}/perun_cli_python:{{ perun_cli_python_container_version }}"
+    source: pull
+    force_source: true
+    state: present
 
 - name: "find old CLI images"
   command:
@@ -76,7 +138,25 @@
   register: oldcliimages
   changed_when: oldcliimages.stdout_lines | length > 0
 
+- name: "find old CLI python images"
+  command:
+    argv:
+      - "docker"
+      - "images"
+      - "-q"
+      - "--filter"
+      - "before={{ perun_container_registry }}/perun_cli_python:{{ perun_cli_python_container_version }}"
+      - "--filter"
+      - "label=org.perun-aai.cli-python"
+  register: oldclipythonimages
+  changed_when: oldclipythonimages.stdout_lines | length > 0
+
 - name: "prune old CLI images"
   when: oldcliimages.stdout_lines | length > 0
   command:
     argv: "{{ [ 'docker', 'rmi' ] + oldcliimages.stdout_lines }}"
+
+- name: "prune old CLI python images"
+  when: oldclipythonimages.stdout_lines | length > 0
+  command:
+    argv: "{{ [ 'docker', 'rmi' ] + oldclipythonimages.stdout_lines }}"

--- a/templates/perun-cli-python-env.j2
+++ b/templates/perun-cli-python-env.j2
@@ -1,0 +1,20 @@
+# this is a Docker environment file, not a shell file, no shell substitution happens
+# no special handling of quotation marks, they are part of the value!
+# see https://docs.docker.com/compose/env-file/#syntax-rules
+# and https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file
+
+# Perun agent variables
+PERUN_CLI_PYTHON_USER=perun
+PERUN_CLI_PYTHON_PASSWORD={{ perun_apache_basicAuth_user_perun_password }}
+PERUN_CLI_PYTHON_AUTH_TYPE=basic
+
+# inherit these variables from the calling environment
+LOGNAME
+USER
+
+# system locale
+LANG=en_US.UTF-8
+LANGUAGE=en_US:en
+
+# Oracle locale https://www.oracle.com/cz/database/technologies/faq-nls-lang.html
+NLS_LANG=CZECH_CZECH REPUBLIC.AL32UTF8

--- a/templates/perun-cli-python-instances.j2
+++ b/templates/perun-cli-python-instances.j2
@@ -1,0 +1,15 @@
+{
+  "default_instance": "perun-host",
+  "instances": {
+    "perun-host": {
+      "issuer": "",
+      "metadata_url": "",
+      "client_id": "",
+      "scopes": "openid perun_api perun_admin offline_access",
+      "perun_api_url": "",
+      "perun_api_url_ba": "https://{{ perun_api_for_cli_hostname }}/ba/rpc/",
+      "perun_api_url_krb": "",
+      "mfa": false
+    }
+  }
+}


### PR DESCRIPTION
- We now build and deploy both Perl and Python CLI docker images.
- To deploy specific python cli docker image version set "perun_cli_python_container_version" variable (current version is: "p_v50.1.0_cli_v1.2.0").
- You can run python cli docker image on all instances using /usr/local/bin/perun-cli-python (interactively) or using /usr/local/bin/perun-script-cli-python and pass custom python script and params to it.
- Docker image is configured to use perun admin account and call basic-auth API endpoint.