### PR TITLE
Allow setting custom OIDCCryptoPassphrase

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -710,6 +710,7 @@ perun_apache_oauth_introspection_url: https://login.example.org/oidc/introspecti
 perun_apache_oauth_introspection_cache_timeout_seconds: 300
 perun_apache_oauth_client_id: xxx-xxxx-xxx-xxx-x-x-x-x-xxxx
 perun_apache_oauth_client_secret: XXXXXXXXXXXXXXXXXXXXXXXXXXXX
+perun_apache_oauth_cache_crypto_secret: "tcXtrGbIlRWXkrT7"
 perun_apache_csp_default_src: ""
 perun_apache_csp_script_src: ""
 perun_apache_csp_frame_src: ""

--- a/templates/sites-enabled/perun-api.conf.j2
+++ b/templates/sites-enabled/perun-api.conf.j2
@@ -187,7 +187,7 @@
     OIDCOAuthAcceptTokenAs header
     OIDCOAuthAcceptTokenAs post
     OIDCOAuthAcceptTokenAs query
-    OIDCCryptoPassphrase tcXtrGbIlRWXkrT7
+    OIDCCryptoPassphrase {{ perun_apache_oauth_cache_crypto_secret }}
     OIDCCacheEncrypt On
     OIDCClaimPrefix AJP_OIDC_CLAIM_
     <LocationMatch "^/oauth/">

--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -397,7 +397,7 @@ ShibCompatValidUser on
   OIDCOAuthAcceptTokenAs header
   OIDCOAuthAcceptTokenAs post
   OIDCOAuthAcceptTokenAs query
-  OIDCCryptoPassphrase tcXtrGbIlRWXkrT7
+  OIDCCryptoPassphrase {{ perun_apache_oauth_cache_crypto_secret }}
   OIDCCacheEncrypt On
   OIDCClaimPrefix AJP_OIDC_CLAIM_
   <LocationMatch "^/oauth/">


### PR DESCRIPTION
- Allow setting custom encryption passphrase for oidc cache using "perun_apache_oauth_cache_crypto_secret". Default value is set to previously used defualt from vhost templates.