### PR TITLE
Remove LDAP related credentials from perun-ldapc.properties

### DIFF
--- a/templates/perun-ldapc.properties.j2
+++ b/templates/perun-ldapc.properties.j2
@@ -7,7 +7,3 @@ ldap.password={{ perun_ldap_data_password }}
 ldap.consumerName=ldapcConsumer
 ldap.loginNamespace={{ perun_ldap_sasl_login_namespace }}
 ldap.stateFile=./perun-ldapc-last-state
-
-# password for {{ perun_ldap_data_admin_dn }}: {{ perun_ldap_data_password }}
-# password for cn=admin,cn=config: {{ perun_ldap_config_password }}
-# password for cn=proxy,{{ perun_ldap_basedn }}: {{ perun_ldap_proxy_password }}


### PR DESCRIPTION
- They are not part of the configuration, it was just a handy place for them to be found, but it is best if they stay only where necessary.