### PR TITLE
Added new configuration options in perun.properties for new registrar

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,6 +88,8 @@ perun_rpc_dont_lookup_users:
   - perunRpc
   - perunSynchronizer
 perun_rpc_additional_dont_lookup_users: []
+perun_rpc_new_registrar_api_url: ""
+perun_rpc_new_registrar_api_secret: ""
 perun_rpc_rt_url: ""
 perun_rpc_rt_defaultQueue: ""
 perun_rpc_rt_serviceuser_username: ""

--- a/templates/perun.properties.j2
+++ b/templates/perun.properties.j2
@@ -8,6 +8,9 @@ perun.engine.principals = {{ perun_rpc_engine_principals|join(', ') }}
 
 # Principals for the Registrar
 perun.registrar.principals =
+# Settings for new registrar (when perun calls new registrar API)
+perun.registrar.apiUrl={{ perun_rpc_new_registrar_api_url }}
+perun.registrar.apiSecret={{ perun_rpc_new_registrar_api_secret }}
 
 # Principals for the Notificator
 perun.notification.principals = perunNotifications


### PR DESCRIPTION
- You can set API URL and shared secret for new registrar with vars: perun_rpc_new_registrar_api_url and perun_rpc_new_registrar_api_secret. They are by default empty (unset).