### PR TITLE
Support templating for perun-extSources.xml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -181,6 +181,10 @@ perun_rpc_app_allowed_roles: []
 
 perun_namespaces_properties: ""
 
+# Support using template for "perun-extSources.xml" in RPC config (default is no, default path to files of each instance)
+perun_use_template_for_extsources_xml: no
+perun_extsources_xml_template_path: "files/{{ perun_instance_hostname }}/perun-extSources.xml.j2"
+
 # old GUI
 perun_oldgui_defaultRtQueue: "perun"
 perun_oldgui_getAttributesListForMemberTables:

--- a/tasks/perun_rpc.yml
+++ b/tasks/perun_rpc.yml
@@ -103,7 +103,8 @@
     mode: '0440'
   notify: "restart perun_rpc"
 
-- name: "create perun-extSources.xml"
+- name: "create perun-extSources.xml from file"
+  when: not perun_use_template_for_extsources_xml
   copy:
     src: "{{ lookup('first_found', params) }}"
     dest: "/etc/perun/rpc/perun-extSources.xml"
@@ -117,6 +118,16 @@
       paths:
         - "files/{{ perun_instance_hostname }}"
         - "files"
+  notify: "restart perun_rpc"
+
+- name: "create perun-extSources.xml from template"
+  when: perun_use_template_for_extsources_xml
+  template:
+    src: "{{ perun_extsources_xml_template_path }}"
+    dest: "/etc/perun/rpc/perun-extSources.xml"
+    owner: root
+    group: perunrpc
+    mode: '0440'
   notify: "restart perun_rpc"
 
 - name: "create login-namespaces-rules-config.yml"


### PR DESCRIPTION
- You can enable templating of perun-extSources.xml by setting
  `perun_use_template_for_extsources_xml` to `"yes"`.
  Default location of a template is the same, just with .j2 suffix.
- You can set custom path to the template file by setting
  `perun_extsources_xml_template_path` var for each instance or group.
  eg.: `"files/{{ perun_instance_hostname }}/perun-extSources.xml.j2"`
  or `"{{ playbook_dir }}/templates/perun-extSources.xml.j2"` etc.