### PR TITLE
Remove Google domains from CSP

### DIFF
--- a/templates/sites-enabled/perun-admin.conf.j2
+++ b/templates/sites-enabled/perun-admin.conf.j2
@@ -91,7 +91,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_oauth_csp_url }} https://{{ perun_ngui_admin_api_hostname if perun_ngui_admin_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_oauth_csp_url }} https://{{ perun_ngui_admin_api_hostname if perun_ngui_admin_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: ; font-src 'self' ; style-src 'self' 'unsafe-inline'"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-consolidator.conf.j2
+++ b/templates/sites-enabled/perun-consolidator.conf.j2
@@ -81,7 +81,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_consolidator_oauth_csp_url }} https://{{ perun_ngui_consolidator_api_hostname if perun_ngui_consolidator_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: https: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_consolidator_oauth_csp_url }} https://{{ perun_ngui_consolidator_api_hostname if perun_ngui_consolidator_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: https: ; font-src 'self' ; style-src 'self' 'unsafe-inline'"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-linker.conf.j2
+++ b/templates/sites-enabled/perun-linker.conf.j2
@@ -81,7 +81,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_linker_oauth_csp_url }} https://{{ perun_ngui_linker_api_hostname if perun_ngui_linker_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_linker_oauth_csp_url }} https://{{ perun_ngui_linker_api_hostname if perun_ngui_linker_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: ; font-src 'self' ; style-src 'self' 'unsafe-inline'"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-profile.conf.j2
+++ b/templates/sites-enabled/perun-profile.conf.j2
@@ -86,7 +86,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_profile_oauth_csp_url }} https://{{ perun_ngui_profile_api_hostname if perun_ngui_profile_api_hostname is defined else perun_api_hostname }} {{ perun_ngui_mfa.api_url if perun_ngui_mfa.api_url is defined else '' }} ; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_profile_oauth_csp_url }} https://{{ perun_ngui_profile_api_hostname if perun_ngui_profile_api_hostname is defined else perun_api_hostname }} {{ perun_ngui_mfa.api_url if perun_ngui_mfa.api_url is defined else '' }} ; img-src 'self' data: ; font-src 'self' ; style-src 'self' 'unsafe-inline'"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-publications.conf.j2
+++ b/templates/sites-enabled/perun-publications.conf.j2
@@ -86,7 +86,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_publications_oauth_csp_url }} https://{{ perun_ngui_publications_api_hostname if perun_ngui_publications_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_publications_oauth_csp_url }} https://{{ perun_ngui_publications_api_hostname if perun_ngui_publications_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: ; font-src 'self' ; style-src 'self' 'unsafe-inline'"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/

--- a/templates/sites-enabled/perun-pwdreset.conf.j2
+++ b/templates/sites-enabled/perun-pwdreset.conf.j2
@@ -86,7 +86,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_oauth_authority }} https://{{ perun_api_hostname }} ; img-src 'self' data: ; font-src https://fonts.gstatic.com https://fonts.googleapis.com ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_oauth_authority }} https://{{ perun_api_hostname }} ; img-src 'self' data: ; font-src 'self' ; style-src 'self' 'unsafe-inline'"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/


### PR DESCRIPTION
- Fonts and CSS are no longer loaded from Google domains.
- Requires perun GUI version at least 20.11.x