### PR TITLE
decoupled rpc container hostname from Docker

### DIFF
--- a/tasks/perun_apache.yml
+++ b/tasks/perun_apache.yml
@@ -3,6 +3,10 @@
     name: perun_rpc
   register: perun_rpc_container
 
+- name: "set perun_rpc_container_hostname variable for templates"
+  set_fact:
+    perun_rpc_container_hostname: "{{ perun_rpc_container.container.Config.Hostname }}"
+
 - name: "create /etc/perun/apache/sites-enabled directory"
   file:
     path: /etc/perun/apache/sites-enabled

--- a/templates/sites-enabled/perun-api-cert.conf.j2
+++ b/templates/sites-enabled/perun-api-cert.conf.j2
@@ -100,11 +100,11 @@
     ##     RPC                      ####
     ####################################
 
-    <Proxy "ajp://{{ perun_rpc_container.container.Config.Hostname }}:8009/">
+    <Proxy "ajp://{{ perun_rpc_container_hostname }}:8009/">
         ProxySet secret={{ perun_rpc_ajp_secret }}
     </Proxy>
 
-    RewriteRule ^/(.*)/rpc/(.*)$ ajp://{{ perun_rpc_container.container.Config.Hostname }}:8009/perun-rpc/$2 [P,QSA,E=AJP_SSL_CLIENT_VERIFY:%{SSL:SSL_CLIENT_VERIFY},E=AJP_SSL_CLIENT_I_DN:%{SSL:SSL_CLIENT_I_DN},E=AJP_SSL_CLIENT_S_DN:%{SSL:SSL_CLIENT_S_DN},E=AJP_SSL_CLIENT_CERT:%{SSL:SSL_CLIENT_CERT}]
+    RewriteRule ^/(.*)/rpc/(.*)$ ajp://{{ perun_rpc_container_hostname }}:8009/perun-rpc/$2 [P,QSA,E=AJP_SSL_CLIENT_VERIFY:%{SSL:SSL_CLIENT_VERIFY},E=AJP_SSL_CLIENT_I_DN:%{SSL:SSL_CLIENT_I_DN},E=AJP_SSL_CLIENT_S_DN:%{SSL:SSL_CLIENT_S_DN},E=AJP_SSL_CLIENT_CERT:%{SSL:SSL_CLIENT_CERT}]
 
     ####################################
     ##     AuthN Methods            ####

--- a/templates/sites-enabled/perun-api.conf.j2
+++ b/templates/sites-enabled/perun-api.conf.j2
@@ -115,11 +115,11 @@
     ##     RPC                      ####
     ####################################
 
-    <Proxy "ajp://{{ perun_rpc_container.container.Config.Hostname }}:8009/">
+    <Proxy "ajp://{{ perun_rpc_container_hostname }}:8009/">
         ProxySet secret={{ perun_rpc_ajp_secret }}
     </Proxy>
 
-    RewriteRule ^/(.*)/rpc/(.*)$ ajp://{{ perun_rpc_container.container.Config.Hostname }}:8009/perun-rpc/$2 [P,QSA]
+    RewriteRule ^/(.*)/rpc/(.*)$ ajp://{{ perun_rpc_container_hostname }}:8009/perun-rpc/$2 [P,QSA]
 
     ####################################
     ##     AuthN Methods            ####

--- a/templates/sites-enabled/perun-cert.conf.j2
+++ b/templates/sites-enabled/perun-cert.conf.j2
@@ -123,11 +123,11 @@
     ##     RPC                      ####
     ####################################
 
-    <Proxy "ajp://{{ perun_rpc_container.container.Config.Hostname }}:8009/">
+    <Proxy "ajp://{{ perun_rpc_container_hostname }}:8009/">
     ProxySet secret={{ perun_rpc_ajp_secret }}
     </Proxy>
 
-    RewriteRule ^/(.*)/rpc/(.*)$ ajp://{{ perun_rpc_container.container.Config.Hostname }}:8009/perun-rpc/$2 [P,QSA,E=AJP_CSRF_PROTECTION_ENABLED:{{ perun_apache_csrf_protection_enabled | bool | to_json }},E=AJP_SSL_CLIENT_VERIFY:%{SSL:SSL_CLIENT_VERIFY},E=AJP_SSL_CLIENT_I_DN:%{SSL:SSL_CLIENT_I_DN},E=AJP_SSL_CLIENT_S_DN:%{SSL:SSL_CLIENT_S_DN},E=AJP_SSL_CLIENT_CERT:%{SSL:SSL_CLIENT_CERT}]
+    RewriteRule ^/(.*)/rpc/(.*)$ ajp://{{ perun_rpc_container_hostname }}:8009/perun-rpc/$2 [P,QSA,E=AJP_CSRF_PROTECTION_ENABLED:{{ perun_apache_csrf_protection_enabled | bool | to_json }},E=AJP_SSL_CLIENT_VERIFY:%{SSL:SSL_CLIENT_VERIFY},E=AJP_SSL_CLIENT_I_DN:%{SSL:SSL_CLIENT_I_DN},E=AJP_SSL_CLIENT_S_DN:%{SSL:SSL_CLIENT_S_DN},E=AJP_SSL_CLIENT_CERT:%{SSL:SSL_CLIENT_CERT}]
 
     ####################################
     ##     Identity Consolidator    ####

--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -189,11 +189,11 @@ ShibCompatValidUser on
   ##     RPC                      ####
   ####################################
 
-  <Proxy "ajp://{{ perun_rpc_container.container.Config.Hostname }}:8009/">
+  <Proxy "ajp://{{ perun_rpc_container_hostname }}:8009/">
     ProxySet secret={{ perun_rpc_ajp_secret }}
   </Proxy>
   # General rewrite rule
-  RewriteRule ^/(.*)/rpc/(.*)$ ajp://{{ perun_rpc_container.container.Config.Hostname }}:8009/perun-rpc/$2 [P,QSA,E=AJP_CSRF_PROTECTION_ENABLED:{{ perun_apache_csrf_protection_enabled | bool | to_json }},E=AJP_SSL_CLIENT_VERIFY:%{SSL:SSL_CLIENT_VERIFY},E=AJP_SSL_CLIENT_I_DN:%{SSL:SSL_CLIENT_I_DN},E=AJP_SSL_CLIENT_S_DN:%{SSL:SSL_CLIENT_S_DN},E=AJP_SSL_CLIENT_CERT:%{SSL:SSL_CLIENT_CERT}]
+  RewriteRule ^/(.*)/rpc/(.*)$ ajp://{{ perun_rpc_container_hostname }}:8009/perun-rpc/$2 [P,QSA,E=AJP_CSRF_PROTECTION_ENABLED:{{ perun_apache_csrf_protection_enabled | bool | to_json }},E=AJP_SSL_CLIENT_VERIFY:%{SSL:SSL_CLIENT_VERIFY},E=AJP_SSL_CLIENT_I_DN:%{SSL:SSL_CLIENT_I_DN},E=AJP_SSL_CLIENT_S_DN:%{SSL:SSL_CLIENT_S_DN},E=AJP_SSL_CLIENT_CERT:%{SSL:SSL_CLIENT_CERT}]
 
 {{ perun_apache_other_rewrites }}
   ####################################


### PR DESCRIPTION
The hostname for communication from Apache container to perun_rpc container should not be expected to come from Docker, because it may be the name of a Kubernetes service.