### PR TITLE
Simplified all certificate handling in Apache templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,6 @@ perun_use_certbot_certificates: no
 perun_use_remote_certs: no
 # When "perun_use_remote_certs" is set to "yes", you must define paths to remote certs
 # You need to define at least "host" certs (if one cert is used for all hostnames).
-# See "prefix" values in "other_certs" variable for possible keys (like "api", "admin", "profile", "pwdreset", ....)
 perun_remote_certs: {}
 #perun_remote_certs:
 #  host:
@@ -309,7 +308,6 @@ perun_ngui_password_help_cs:
 # new GUI Admin
 perun_ngui_admin_hostname: "perun.aai.example.org"
 perun_ngui_admin_hostname_aliases: []
-perun_ngui_admin_tls_cert_same_as_host: yes
 perun_ngui_admin_document_title: "Perun - Identity and Access Management"
 perun_ngui_admin_header_label_en: "Identity and Access Management"
 perun_ngui_admin_header_label_cs: "Správa identit a přístupu"
@@ -351,7 +349,6 @@ perun_ngui_admin_display_search: no
 perun_ngui_profile_enabled: no
 perun_ngui_profile_hostname: profile.aai.example.org
 perun_ngui_profile_hostname_aliases: []
-perun_ngui_profile_tls_cert_same_as_host: yes
 perun_ngui_profile_instance_favicon: false
 perun_ngui_profile_auto_oauth_redirect: true
 perun_ngui_profile_auto_service_access_redirect: false
@@ -438,7 +435,6 @@ perun_ngui_profile_orcid_ext_source_name: ''
 perun_ngui_consolidator_enabled: no
 perun_ngui_consolidator_hostname: "perun.aai.example.org"
 perun_ngui_consolidator_hostname_aliases: []
-perun_ngui_consolidator_tls_cert_same_as_host: yes
 perun_ngui_consolidator_document_title: "Consolidator"
 perun_ngui_consolidator_other_apps:
   en:
@@ -467,7 +463,6 @@ perun_ngui_consolidator_path_to_idp_logo_height_userinfo: ["target_backend", "lo
 perun_ngui_linker_enabled: no
 perun_ngui_linker_hostname: "perun.aai.example.org"
 perun_ngui_linker_hostname_aliases: []
-perun_ngui_linker_tls_cert_same_as_host: yes
 perun_ngui_linker_document_title: "Linker"
 perun_ngui_linker_client_id: "xxx-xxxx-xxxx-xxx-xx-xxx"
 perun_ngui_linker_oauth_authority: '{{ perun_ngui_oauth_authority }}'
@@ -486,7 +481,6 @@ perun_ngui_linker_instance_favicon: false
 perun_ngui_pwdreset_enabled: no
 perun_ngui_pwdreset_hostname: pwdreset.aai.example.org
 perun_ngui_pwdreset_hostname_aliases: []
-perun_ngui_pwdreset_tls_cert_same_as_host: yes
 perun_ngui_pwdreset_header_label_en: "Password reset"
 perun_ngui_pwdreset_header_label_cs: "Reset hesla"
 perun_ngui_pwdreset_document_title:
@@ -521,7 +515,6 @@ perun_ngui_pwdreset_default_namespace: ""
 perun_ngui_publications_enabled: no
 perun_ngui_publications_hostname: publications.aai.example.org
 perun_ngui_publications_hostname_aliases: []
-perun_ngui_publications_tls_cert_same_as_host: yes
 perun_ngui_publications_auto_oauth_redirect: true
 perun_ngui_publications_oauth_authority: '{{ perun_ngui_oauth_authority }}'
 perun_ngui_publications_oauth_callback: "https://{{ perun_ngui_publications_hostname }}/api-callback"
@@ -572,12 +565,10 @@ perun_ngui_publications_link_to_admin_gui_by_roles: [
 perun_api_enabled: no
 perun_api_hostname: "{{ perun_rpc_hostname }}"
 perun_api_hostname_aliases: []
-perun_api_tls_cert_same_as_host: yes
 # second API with other OIDC
 perun_api_alternative_enabled: no
 perun_api_alternative_hostname: perun-api-second.example.org
 perun_api_alternative_hostname_aliases: []
-perun_api_alternative_tls_cert_same_as_host: yes
 perun_apache_oauth_alternative_introspection_url: https://other.oidc.provider/oidc/introspection
 perun_apache_oauth_alternative_client_id: "yyyyyyyyy-yyyyyyyyy-yyyyyyyyy-yyyyyyyy"
 perun_apache_oauth_alternative_client_secret: "YYYYYYYYYYYYYYYYY"
@@ -586,11 +577,9 @@ perun_apache_oauth_alternative_client_secret: "YYYYYYYYYYYYYYYYY"
 perun_api_cert_enabled: no
 perun_api_cert_hostname: perun-api-cert.example.org
 perun_api_cert_hostname_aliases: []
-perun_api_cert_tls_cert_same_as_host: yes
 perun_api_cert_alternative_enabled: no
 perun_api_cert_alternative_hostname: perun-api-cert-second.example.org
 perun_api_cert_alternative_hostname_aliases: []
-perun_api_cert_alternative_tls_cert_same_as_host: yes
 
 # pointers to API for CLI and Engine
 perun_api_for_cli_hostname: "{{ perun_api_hostname }}"
@@ -700,7 +689,6 @@ perun_apache_igtf_certs: no
 perun_apache_cert_hostname_enabled: no
 perun_apache_cert_hostname: perun-cert.example.org
 perun_apache_cert_hostname_aliases: []
-perun_apache_cert_hostname_tls_cert_same_as_host: yes
 perun_apache_non_enabled: yes
 perun_apache_kerberos_enabled: no
 perun_apache_kerberos_realms:
@@ -860,73 +848,51 @@ perun_certbot_mounts:
   - { type: bind, source: /etc/letsencrypt/live, target: /etc/letsencrypt/live, read_only: yes }
   - { type: bind, source: /etc/letsencrypt/archive, target: /etc/letsencrypt/archive, read_only: yes }
 
-# structure for looping over alternative hostnames and their certificates
+# structure for looping over alternative hostnames
 other_certs:
   - cond: perun_api_enabled
     hostname: perun_api_hostname
     aliases: perun_api_hostname_aliases
-    prefix: api
-    same: perun_api_tls_cert_same_as_host
 
   - cond: perun_api_alternative_enabled
     hostname: perun_api_alternative_hostname
     aliases: perun_api_alternative_hostname_aliases
-    prefix: altapi
-    same: perun_api_alternative_tls_cert_same_as_host
 
   - cond: perun_api_cert_enabled
     hostname: perun_api_cert_hostname
     aliases: perun_api_cert_hostname_aliases
-    prefix: apicert
-    same: perun_api_cert_tls_cert_same_as_host
 
   - cond: perun_api_cert_alternative_enabled
     hostname: perun_api_cert_alternative_host
     aliases: perun_api_cert_alternative_hostname_aliases
-    prefix: altapicert
-    same: perun_api_cert_alternative_tls_cert_same_as_host
 
   - cond: perun_apache_cert_hostname_enabled
     hostname: perun_apache_cert_hostname
     aliases: perun_apache_cert_hostname_aliases
-    prefix: cert
-    same: perun_apache_cert_hostname_tls_cert_same_as_host
 
   - cond: perun_ngui_admin_enabled
     hostname: perun_ngui_admin_hostname
     aliases: perun_ngui_admin_hostname_aliases
-    prefix: admin
-    same: perun_ngui_admin_tls_cert_same_as_host
 
   - cond: perun_ngui_profile_enabled
     hostname: perun_ngui_profile_hostname
     aliases: perun_ngui_profile_hostname_aliases
-    prefix: profile
-    same: perun_ngui_profile_tls_cert_same_as_host
 
   - cond: perun_ngui_pwdreset_enabled
     hostname: perun_ngui_pwdreset_hostname
     aliases: perun_ngui_pwdreset_hostname_aliases
-    prefix: pwdreset
-    same: perun_ngui_pwdreset_tls_cert_same_as_host
 
   - cond: perun_ngui_publications_enabled
     hostname: perun_ngui_publications_hostname
     aliases: perun_ngui_publications_hostname_aliases
-    prefix: publications
-    same: perun_ngui_publications_tls_cert_same_as_host
 
   - cond: perun_ngui_consolidator_enabled
     hostname: perun_ngui_consolidator_hostname
     aliases: perun_ngui_consolidator_hostname_aliases
-    prefix: consolidator
-    same: perun_ngui_consolidator_tls_cert_same_as_host
 
   - cond: perun_ngui_linker_enabled
     hostname: perun_ngui_linker_hostname
     aliases: perun_ngui_linker_hostname_aliases
-    prefix: linker
-    same: perun_ngui_linker_tls_cert_same_as_host
 
 # firewall settings
 # CESNET eduVPN  info https://wiki.cesnet.cz/doku.php?id=interni_sluzby:eduvpn

--- a/tasks/perun_apache.yml
+++ b/tasks/perun_apache.yml
@@ -181,8 +181,6 @@
     owner: root
     group: root
     mode: '0400'
-  vars:
-    perun_cert_prefix: cert
   notify: "restart perun_apache"
 
 - name: "create /etc/perun/apache/sites-enabled/perun-admin.conf"
@@ -203,8 +201,6 @@
     owner: root
     group: root
     mode: '0400'
-  vars:
-    perun_cert_prefix: api
   notify: "restart perun_apache"
 
 - name: "create /etc/perun/apache/sites-enabled/perun-api-alt.conf"
@@ -218,11 +214,9 @@
   vars:
     perun_api_hostname: "{{ perun_api_alternative_hostname }}"
     perun_api_hostname_aliases: "{{ perun_api_alternative_hostname_aliases }}"
-    perun_api_tls_cert_same_as_host: "{{ perun_api_alternative_tls_cert_same_as_host }}"
     perun_apache_oauth_introspection_url: "{{ perun_apache_oauth_alternative_introspection_url }}"
     perun_apache_oauth_client_id: "{{ perun_apache_oauth_alternative_client_id }}"
     perun_apache_oauth_client_secret: "{{ perun_apache_oauth_alternative_client_secret }}"
-    perun_cert_prefix: altapi
   notify: "restart perun_apache"
 
 - name: "create /etc/perun/apache/sites-enabled/perun-api-cert.conf"
@@ -233,8 +227,6 @@
     owner: root
     group: root
     mode: '0400'
-  vars:
-    perun_cert_prefix: apicert
   notify: "restart perun_apache"
 
 - name: "create /etc/perun/apache/sites-enabled/perun-api-cert-alt.conf"
@@ -248,8 +240,6 @@
   vars:
     perun_api_cert_hostname: "{{ perun_api_cert_alternative_hostname }}"
     perun_api_cert_hostname_aliases: "{{ perun_api_cert_alternative_hostname_aliases }}"
-    perun_api_cert_tls_cert_same_as_host: "{{ perun_api_cert_alternative_tls_cert_same_as_host }}"
-    perun_cert_prefix: altapicert
   notify: "restart perun_apache"
 
 - name: "create /etc/perun/apache/sites-enabled/perun-profile.conf"

--- a/tasks/perun_certs.yml
+++ b/tasks/perun_certs.yml
@@ -18,7 +18,7 @@
       loop: "{{ other_certs }}"
       loop_control:
         loop_var: cert_item
-        label: "{{ cert_item.prefix }}"
+        label: "{{ cert_item.hostname }}"
       when: lookup('vars', cert_item.cond)
       set_fact:
         perun_certbot_alt_hostnames: "{{ perun_certbot_alt_hostnames + [ lookup('vars', cert_item.hostname) ] + lookup('vars', cert_item.aliases) }}"
@@ -134,14 +134,6 @@
         src: "/etc/letsencrypt/live/multi/fullchain.pem"
         dest: "{{ perun_certificate_fullchain_file }}"
         force: yes
-
-    - name: "clean old links"
-      loop: "{{ ['api', 'altapi', 'apicert', 'altapicert', 'cert', 'admin', 'profile', 'pwdreset', 'publications', 'consolidator', 'linker'] | product(['key', 'cert', 'chain']) | list }}"
-      loop_control:
-        label: "{{ item[0] }}{{ item[1] }}.pem"
-      file:
-        state: absent
-        path: "{{ perun_certs_dir }}/{{ item[0] }}{{ item[1] }}.pem"
 
 #
 # Handle SERVER certificate using issued cert (in sites repo or remote host)
@@ -298,94 +290,6 @@
           >{{ perun_certificate_fullchain_file }}
       when: certfile.changed
       notify: "restart portainer"
-
-    - name: "assert that cert paths are defined when remote certs are used for 'other_certs'"
-      when: perun_use_remote_certs and lookup('vars', item.cond) and not lookup('vars', item.same)
-      loop: "{{ other_certs }}"
-      loop_control:
-        label: "{{ item.prefix }}"
-      assert:
-        that:
-          - item.prefix in perun_remote_certs
-          - perun_remote_certs[item.prefix].cert | length > 0
-          - perun_remote_certs[item.prefix].key | length > 0
-          - perun_remote_certs[item.prefix].chain | length > 0
-        fail_msg: "Remote certs paths are NOT defined for '{{ item.prefix }}' cert in 'perun_remote_certs'."
-        success_msg: "Remote certs paths are defined for '{{ item.prefix }}' cert in 'perun_remote_certs'."
-
-    - name: "set other certificates"
-      loop: "{{ other_certs }}"
-      loop_control:
-        label: "{{ item.prefix }}"
-      when: lookup('vars', item.cond) and not lookup('vars', item.same)
-      copy:
-        src: "{{ (perun_remote_certs[item.prefix].cert if perun_use_remote_certs and item.prefix in perun_remote_certs else (perun_instance_hostname ~ '/' ~ ('host' if lookup('vars', item.same) else item.prefix ~ 'cert.pem'))) }}"
-        dest: "{{ perun_certs_dir }}/{{ item.prefix }}cert.pem"
-        owner: root
-        group: root
-        mode: 0644
-        remote_src: "{{ perun_use_remote_certs }}"
-      notify:
-        - "restart perun_apache"
-
-    - name: "set other keys"
-      loop: "{{ other_certs }}"
-      loop_control:
-        label: "{{ item.prefix }}"
-      when: lookup('vars', item.cond) and not lookup('vars', item.same)
-      copy:
-        src: "{{ (perun_remote_certs[item.prefix].key if perun_use_remote_certs and item.prefix in perun_remote_certs else (perun_instance_hostname ~ '/' ~ ('host' if lookup('vars', item.same) else item.prefix ~ 'key.pem'))) }}"
-        dest: "{{ perun_certs_dir }}/{{ item.prefix }}key.pem"
-        owner: root
-        group: ssl-cert
-        mode: 0640
-        remote_src: "{{ perun_use_remote_certs }}"
-      notify:
-        - "restart perun_apache"
-
-    - name: "set other chains"
-      loop: "{{ other_certs }}"
-      loop_control:
-        label: "{{ item.prefix }}"
-      when: lookup('vars', item.cond) and not lookup('vars', item.same)
-      copy:
-        src: "{{ (perun_remote_certs[item.prefix].chain if perun_use_remote_certs and item.prefix in perun_remote_certs else (perun_instance_hostname ~ '/' ~ ('host' if lookup('vars', item.same) else item.prefix ~ 'chain.pem'))) }}"
-        dest: "{{ perun_certs_dir }}/{{ item.prefix }}chain.pem"
-        owner: root
-        group: root
-        mode: 0644
-        remote_src: "{{ perun_use_remote_certs }}"
-      notify:
-        - "restart perun_apache"
-
-    - name: "clean unnecessary old links for disabled apps or apps which use same cert as host"
-      block:
-        - name: "clean old links to certs"
-          loop: "{{ other_certs }}"
-          loop_control:
-            label: "{{ item.prefix }}"
-          when: not lookup('vars', item.cond) or (lookup('vars', item.cond) and lookup('vars', item.same))
-          file:
-            path: "{{ perun_certs_dir }}/{{ item.prefix }}cert.pem"
-            state: absent
-
-        - name: "clean old links to keys"
-          loop: "{{ other_certs }}"
-          loop_control:
-            label: "{{ item.prefix }}"
-          when: not lookup('vars', item.cond) or (lookup('vars', item.cond) and lookup('vars', item.same))
-          file:
-            path: "{{ perun_certs_dir }}/{{ item.prefix }}key.pem"
-            state: absent
-
-        - name: "clean old links to chains"
-          loop: "{{ other_certs }}"
-          loop_control:
-            label: "{{ item.prefix }}"
-          when: not lookup('vars', item.cond) or (lookup('vars', item.cond) and lookup('vars', item.same))
-          file:
-            path: "{{ perun_certs_dir }}/{{ item.prefix }}chain.pem"
-            state: absent
 
 #
 # Handle CLIENT certificate using issued cert (in sites repo or remote host)

--- a/templates/sites-enabled/perun-admin.conf.j2
+++ b/templates/sites-enabled/perun-admin.conf.j2
@@ -73,18 +73,8 @@
   RewriteRule ^ /index.html
 
   SSLEngine on
-{% if perun_use_certbot_certificates %}
-  SSLCertificateFile /etc/letsencrypt/live/multi/fullchain.pem
-  SSLCertificateKeyFile /etc/letsencrypt/live/multi/privkey.pem
-{% elif perun_ngui_admin_tls_cert_same_as_host %}
-  SSLCertificateFile /etc/perun/ssl/hostcert.pem
+  SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
   SSLCertificateKeyFile /etc/perun/ssl/hostkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/hostchain.pem
-{% else %}
-  SSLCertificateFile /etc/perun/ssl/admincert.pem
-  SSLCertificateKeyFile /etc/perun/ssl/adminkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/adminchain.pem
-{% endif %}
 
   LogLevel warn ssl:warn rewrite:warn
 

--- a/templates/sites-enabled/perun-api-cert.conf.j2
+++ b/templates/sites-enabled/perun-api-cert.conf.j2
@@ -54,18 +54,8 @@
     ProxyIOBufferSize 65536
 
     SSLEngine on
-{% if perun_use_certbot_certificates %}
-    SSLCertificateFile /etc/letsencrypt/live/multi/fullchain.pem
-    SSLCertificateKeyFile /etc/letsencrypt/live/multi/privkey.pem
-{% elif perun_api_tls_cert_same_as_host %}
-    SSLCertificateFile /etc/perun/ssl/hostcert.pem
+    SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
     SSLCertificateKeyFile /etc/perun/ssl/hostkey.pem
-    SSLCertificateChainFile /etc/perun/ssl/hostchain.pem
-{% else %}
-    SSLCertificateFile /etc/perun/ssl/{{ perun_cert_prefix }}cert.pem
-    SSLCertificateKeyFile /etc/perun/ssl/{{ perun_cert_prefix }}key.pem
-    SSLCertificateChainFile /etc/perun/ssl/{{ perun_cert_prefix }}chain.pem
-{% endif %}
 
     # SSL client certificates authentication
     SSLCACertificatePath /etc/grid-security/certificates/

--- a/templates/sites-enabled/perun-api.conf.j2
+++ b/templates/sites-enabled/perun-api.conf.j2
@@ -54,18 +54,8 @@
     ProxyIOBufferSize 65536
 
     SSLEngine on
-{% if perun_use_certbot_certificates %}
-    SSLCertificateFile /etc/letsencrypt/live/multi/fullchain.pem
-    SSLCertificateKeyFile /etc/letsencrypt/live/multi/privkey.pem
-{% elif perun_api_tls_cert_same_as_host %}
-    SSLCertificateFile /etc/perun/ssl/hostcert.pem
+    SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
     SSLCertificateKeyFile /etc/perun/ssl/hostkey.pem
-    SSLCertificateChainFile /etc/perun/ssl/hostchain.pem
-{% else %}
-    SSLCertificateFile /etc/perun/ssl/{{ perun_cert_prefix }}cert.pem
-    SSLCertificateKeyFile /etc/perun/ssl/{{ perun_cert_prefix }}key.pem
-    SSLCertificateChainFile /etc/perun/ssl/{{ perun_cert_prefix }}chain.pem
-{% endif %}
 
     LogLevel warn ssl:warn rewrite:warn
 

--- a/templates/sites-enabled/perun-cert.conf.j2
+++ b/templates/sites-enabled/perun-cert.conf.j2
@@ -68,19 +68,8 @@
     ProxyIOBufferSize 65536
 
     SSLEngine on
-{% if perun_use_certbot_certificates %}
-    SSLCertificateFile /etc/letsencrypt/live/multi/fullchain.pem
-    SSLCertificateKeyFile /etc/letsencrypt/live/multi/privkey.pem
-{% elif perun_api_tls_cert_same_as_host %}
-    SSLCertificateFile /etc/perun/ssl/hostcert.pem
+    SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
     SSLCertificateKeyFile /etc/perun/ssl/hostkey.pem
-    SSLCertificateChainFile /etc/perun/ssl/hostchain.pem
-{% else %}
-    SSLCertificateFile /etc/perun/ssl/{{ perun_cert_prefix }}cert.pem
-    SSLCertificateKeyFile /etc/perun/ssl/{{ perun_cert_prefix }}key.pem
-    SSLCertificateChainFile /etc/perun/ssl/{{ perun_cert_prefix }}chain.pem
-{% endif %}
-
 
     # SSL client certificates authentication
     SSLCACertificatePath /etc/grid-security/certificates/

--- a/templates/sites-enabled/perun-consolidator.conf.j2
+++ b/templates/sites-enabled/perun-consolidator.conf.j2
@@ -63,19 +63,8 @@
   RewriteRule ^ /index.html
 
   SSLEngine on
-{% if perun_use_certbot_certificates %}
-  SSLCertificateFile /etc/letsencrypt/live/multi/fullchain.pem
-  SSLCertificateKeyFile /etc/letsencrypt/live/multi/privkey.pem
-{% elif perun_ngui_consolidator_tls_cert_same_as_host %}
-  SSLCertificateFile /etc/perun/ssl/hostcert.pem
+  SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
   SSLCertificateKeyFile /etc/perun/ssl/hostkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/hostchain.pem
-{% else %}
-  SSLCertificateFile /etc/perun/ssl/consolidatorcert.pem
-  SSLCertificateKeyFile /etc/perun/ssl/consolidatorkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/consolidatorchain.pem
-{% endif %}
-
 
   LogLevel warn ssl:warn rewrite:warn
 

--- a/templates/sites-enabled/perun-linker.conf.j2
+++ b/templates/sites-enabled/perun-linker.conf.j2
@@ -63,18 +63,8 @@
   RewriteRule ^ /index.html
 
   SSLEngine on
-{% if perun_use_certbot_certificates %}
-  SSLCertificateFile /etc/letsencrypt/live/multi/fullchain.pem
-  SSLCertificateKeyFile /etc/letsencrypt/live/multi/privkey.pem
-{% elif perun_ngui_linker_tls_cert_same_as_host %}
-  SSLCertificateFile /etc/perun/ssl/hostcert.pem
+  SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
   SSLCertificateKeyFile /etc/perun/ssl/hostkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/hostchain.pem
-{% else %}
-  SSLCertificateFile /etc/perun/ssl/linkercert.pem
-  SSLCertificateKeyFile /etc/perun/ssl/linkerkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/linkerchain.pem
-{% endif %}
 
   LogLevel warn ssl:warn rewrite:warn
 

--- a/templates/sites-enabled/perun-profile.conf.j2
+++ b/templates/sites-enabled/perun-profile.conf.j2
@@ -68,18 +68,8 @@
   RewriteRule ^ /index.html
 
   SSLEngine on
-{% if perun_use_certbot_certificates %}
-  SSLCertificateFile /etc/letsencrypt/live/multi/fullchain.pem
-  SSLCertificateKeyFile /etc/letsencrypt/live/multi/privkey.pem
-{% elif perun_ngui_profile_tls_cert_same_as_host %}
-  SSLCertificateFile /etc/perun/ssl/hostcert.pem
+  SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
   SSLCertificateKeyFile /etc/perun/ssl/hostkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/hostchain.pem
-{% else %}
-  SSLCertificateFile /etc/perun/ssl/profilecert.pem
-  SSLCertificateKeyFile /etc/perun/ssl/profilekey.pem
-  SSLCertificateChainFile /etc/perun/ssl/profilechain.pem
-{% endif %}
 
   LogLevel warn ssl:warn rewrite:warn
 

--- a/templates/sites-enabled/perun-publications.conf.j2
+++ b/templates/sites-enabled/perun-publications.conf.j2
@@ -68,18 +68,8 @@
   RewriteRule ^ /index.html
 
   SSLEngine on
-{% if perun_use_certbot_certificates %}
-  SSLCertificateFile /etc/letsencrypt/live/multi/fullchain.pem
-  SSLCertificateKeyFile /etc/letsencrypt/live/multi/privkey.pem
-{% elif perun_ngui_publications_tls_cert_same_as_host %}
-  SSLCertificateFile /etc/perun/ssl/hostcert.pem
+  SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
   SSLCertificateKeyFile /etc/perun/ssl/hostkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/hostchain.pem
-{% else %}
-  SSLCertificateFile /etc/perun/ssl/publicationscert.pem
-  SSLCertificateKeyFile /etc/perun/ssl/publicationskey.pem
-  SSLCertificateChainFile /etc/perun/ssl/publicationschain.pem
-{% endif %}
 
   LogLevel warn ssl:warn rewrite:warn
 

--- a/templates/sites-enabled/perun-pwdreset.conf.j2
+++ b/templates/sites-enabled/perun-pwdreset.conf.j2
@@ -68,18 +68,8 @@
   RewriteRule ^ /index.html
 
   SSLEngine on
-{% if perun_use_certbot_certificates %}
-  SSLCertificateFile /etc/letsencrypt/live/multi/fullchain.pem
-  SSLCertificateKeyFile /etc/letsencrypt/live/multi/privkey.pem
-{% elif perun_ngui_pwdreset_tls_cert_same_as_host %}
-  SSLCertificateFile /etc/perun/ssl/hostcert.pem
+  SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
   SSLCertificateKeyFile /etc/perun/ssl/hostkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/hostchain.pem
-{% else %}
-  SSLCertificateFile /etc/perun/ssl/pwdresetcert.pem
-  SSLCertificateKeyFile /etc/perun/ssl/pwdresetkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/pwdresetchain.pem
-{% endif %}
 
   LogLevel warn ssl:warn rewrite:warn
 

--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -73,10 +73,8 @@ ShibCompatValidUser on
   #### SSL
 
   SSLEngine on
-
-  SSLCertificateFile /etc/perun/ssl/hostcert.pem
+  SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
   SSLCertificateKeyFile /etc/perun/ssl/hostkey.pem
-  SSLCertificateChainFile /etc/perun/ssl/hostchain.pem
 
 {% if perun_apache_igtf_certs and not perun_apache_cert_hostname_enabled %}
   # SSL client certificates authentication


### PR DESCRIPTION
* Simplified all certificate handling in Apache templates to:
  ```
  SSLCertificateFile /etc/perun/ssl/hostfullchain.pem
  ```
  The file always exists (created by certbot or by ansible task from source cert and chain) and no other files are needed.

* Removed unnecessary tasks from Ansible. If you used specific certs for api/gui domains you need to cleanup them by yourself. 

BREAKING CHANGES:

* Setting custom certificate for gui/api domains is no longer supported. You need to have one certificate for all (either list of domains or asterisk cert) provided by either certbot (eg. LetsEncrypt) or provided as file in /files or located somewhere on the remote machine.
* Variables `perun_ngui_[admin|profile|consolidator|linker|pwdreset|publications]_tls_cert_same_as_host`  has been removed as it is in principle always "yes". Same goes for variables with similar names for cert and api domains.