### PR TITLE
Lower size of each journald file from 1GB to 100MB

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -973,6 +973,6 @@ perun_journald_config: |
   # keep free at least 20% of disk
   SystemKeepFree={{ (log_disk.size_total * 0.2 / 1073741824) | int }}G
   # controls how large individual journal files in /var/log/journal may grow at most
-  SystemMaxFileSize=1G
-  # controls how many individual journal files to keep at most
-  SystemMaxFiles={{ (log_disk.size_total * 0.3 / 1073741824) | int }}
+  SystemMaxFileSize=100M
+  # Do not limit number of files (default 100), prefer keeping logest history based on SystemMaxUser and SystemKeepFree
+  SystemMaxFiles=0


### PR DESCRIPTION
- Lowering the size of each journald file 10x means that cleanup of disk space (in case of logging burst) is done 10x more often. Keep in mind that in case of I/O burst writing to a disk takes priority before deleting the old files :-(, so trying to do it more often should help.
- Set number of journal files to unlimited (default is 100) in order to
  maximize logs history and use maximum disk space from SystemMaxUse setting.