### PR TITLE
Added registrar_api_url to instanceConfig.json for admin GUI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -344,6 +344,7 @@ perun_ngui_admin_other_apps:
 perun_ngui_admin_other_apps_custom:
 # set to "yes" and configure "globalSearch_String_policy" policy on backend to display global search to proper roles
 perun_ngui_admin_display_search: no
+perun_ngui_admin_new_registrar_api_url: "{{ perun_rpc_new_registrar_api_url }}"
 
 #new GUI Profile
 perun_ngui_profile_enabled: no

--- a/templates/instance_configs/instanceConfig.json.j2
+++ b/templates/instance_configs/instanceConfig.json.j2
@@ -8,6 +8,9 @@
 {% else %}
   "api_url": "https://{{ perun_api_hostname }}/oauth/rpc",
 {% endif %}
+{% if perun_ngui_admin_new_registrar_api_url is defined %}
+  "registrar_api_url": "{{ perun_ngui_admin_new_registrar_api_url }}",
+{% endif %}
   "document_title": {
     "en": "{{ perun_ngui_admin_document_title }}"
   },

--- a/templates/sites-enabled/perun-admin.conf.j2
+++ b/templates/sites-enabled/perun-admin.conf.j2
@@ -91,7 +91,7 @@
   # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
   Header always set X-XSS-Protection "1; mode=block"
   # https://scotthelme.co.uk/content-security-policy-an-introduction/
-  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_oauth_csp_url }} https://{{ perun_ngui_admin_api_hostname if perun_ngui_admin_api_hostname is defined else perun_api_hostname }}; img-src 'self' data: ; font-src 'self' ; style-src 'self' 'unsafe-inline'"
+  Header always set Content-Security-Policy "default-src 'self' ; connect-src 'self' {{ perun_ngui_oauth_csp_url }} https://{{ perun_ngui_admin_api_hostname if perun_ngui_admin_api_hostname is defined else perun_api_hostname }} {{ perun_ngui_admin_new_registrar_api_url }}; img-src 'self' data: ; font-src 'self' ; style-src 'self' 'unsafe-inline'"
   # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   # https://scotthelme.co.uk/a-new-security-header-feature-policy/


### PR DESCRIPTION
- Added new var "perun_ngui_admin_new_registrar_api_url" which is by default same as "perun_rpc_new_registrar_api_url" is used in NGUI Admin instanceConfig.json and CSP to enable calls to new Registrar API.
- Note that RPC var is required to end with "/api" but GUI var is not. This might be specific to new registrar deployment.