### PR TITLE
Change docker registry for Perun IDM images

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -838,7 +838,7 @@ perun_postgresql_version: 17
 perun_portainer_version: latest
 
 # prefix for containers
-perun_container_registry: "gitlab-registry.cesnet.cz/712/deployment/idm/perun_idm_docker"
+perun_container_registry: "hub.cerit.io/perunidm"
 
 # directory with SSL/TLS certificates and keys
 perun_certs_dir: "/etc/perun/ssl"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,10 +99,7 @@
     name: cesnet.docker
   vars:
     docker_packages_hold: true
-    docker_registries:
-      - url: gitlab-registry.cesnet.cz
-        username: gitlab-deploy-token-712
-        password: gldt-TcDbEs8Yj-cX4KPmM1Wq
+    docker_registries: []
     docker_local_network_name: perun_net
     docker_portainer_install: true
     docker_portainer_version: "{{ perun_portainer_version }}"

--- a/tasks/perun_cli.yml
+++ b/tasks/perun_cli.yml
@@ -154,9 +154,9 @@
 - name: "prune old CLI images"
   when: oldcliimages.stdout_lines | length > 0
   command:
-    argv: "{{ [ 'docker', 'rmi' ] + oldcliimages.stdout_lines }}"
+    argv: "{{ [ 'docker', 'rmi', '--force' ] + oldcliimages.stdout_lines }}"
 
 - name: "prune old CLI python images"
   when: oldclipythonimages.stdout_lines | length > 0
   command:
-    argv: "{{ [ 'docker', 'rmi' ] + oldclipythonimages.stdout_lines }}"
+    argv: "{{ [ 'docker', 'rmi', '--force' ] + oldclipythonimages.stdout_lines }}"


### PR DESCRIPTION
- Migrate docker registry from `gitlab-registry.cesnet.cz` to `hub.cerit.io`.
- Registry is public, you don't have to have access token.
- Old CLI docker images will be cleaned when deploying new version
  (added force to "docker rmi" to handle migration).

Former docker image registry/name:

`gitlab-registry.cesnet.cz/712/deployment/idm/perun_idm_docker/perun_rpc:v53.1.0`

New docker image registry/name:

`hub.cerit.io/perunidm/perun_rpc:v53.1.0`

Same for the other images.