### PR TITLE
Removed unnecessary task for setting LE renewal profile

### DIFF
--- a/tasks/perun_certs.yml
+++ b/tasks/perun_certs.yml
@@ -43,14 +43,6 @@
         certbot_install_hooks: no
         certbot_account_options: "{{ perun_certbot_account_options }}"
 
-    - name: "temporary set preferred profile to 'tlsclient' to support client authentication until 13.5.2026"
-      ini_file:
-        path: /etc/letsencrypt/renewal/multi.conf
-        section: "renewalparams"
-        option: "preferred_profile"
-        value: "tlsclient"
-        state: "{{ 'present' if ansible_facts['date_time'].date < '2026-05-13' else 'absent' }}"
-
     - name: "create perun_prehook.sh"
       copy:
         dest: /etc/letsencrypt/renewal-hooks/pre/perun_prehook.sh


### PR DESCRIPTION
- LE no longer supports tlsclient profile so there is no need to keep fixup task after 13.5.2026.