### PR TITLE
added optional ACME challenge config

### DIFF
--- a/templates/sites-enabled/perun-admin.conf.j2
+++ b/templates/sites-enabled/perun-admin.conf.j2
@@ -10,6 +10,9 @@
 {% for alias in perun_ngui_admin_hostname_aliases %}
   ServerAlias {{ alias }}
 {% endfor %}
+
+  IncludeOptional /etc/perun/apache/acme.conf
+
   Redirect / https://{{ perun_ngui_admin_hostname }}/
 </VirtualHost>
 

--- a/templates/sites-enabled/perun-api-cert.conf.j2
+++ b/templates/sites-enabled/perun-api-cert.conf.j2
@@ -10,6 +10,9 @@
 {% for alias in perun_api_cert_hostname_aliases %}
     ServerAlias {{ alias }}
 {% endfor %}
+
+    IncludeOptional /etc/perun/apache/acme.conf
+
     Redirect / https://{{ perun_api_cert_hostname }}/
 </VirtualHost>
 

--- a/templates/sites-enabled/perun-api.conf.j2
+++ b/templates/sites-enabled/perun-api.conf.j2
@@ -10,6 +10,9 @@
 {% for alias in perun_api_hostname_aliases %}
     ServerAlias {{ alias }}
 {% endfor %}
+
+    IncludeOptional /etc/perun/apache/acme.conf
+
     Redirect / https://{{ perun_api_hostname }}/
 </VirtualHost>
 

--- a/templates/sites-enabled/perun-cert.conf.j2
+++ b/templates/sites-enabled/perun-cert.conf.j2
@@ -10,6 +10,9 @@
 {% for alias in perun_apache_cert_hostname_aliases %}
     ServerAlias {{ alias }}
 {% endfor %}
+
+    IncludeOptional /etc/perun/apache/acme.conf
+
     Redirect / https://{{ perun_apache_cert_hostname }}/
 </VirtualHost>
 

--- a/templates/sites-enabled/perun-consolidator.conf.j2
+++ b/templates/sites-enabled/perun-consolidator.conf.j2
@@ -10,6 +10,9 @@
 {% for alias in perun_ngui_consolidator_hostname_aliases %}
   ServerAlias {{ alias }}
 {% endfor %}
+
+  IncludeOptional /etc/perun/apache/acme.conf
+
   Redirect / https://{{ perun_ngui_consolidator_hostname }}/
 </VirtualHost>
 

--- a/templates/sites-enabled/perun-linker.conf.j2
+++ b/templates/sites-enabled/perun-linker.conf.j2
@@ -10,6 +10,9 @@
 {% for alias in perun_ngui_linker_hostname_aliases %}
    ServerAlias {{ alias }}
 {% endfor %}
+
+  IncludeOptional /etc/perun/apache/acme.conf
+
   Redirect / https://{{ perun_ngui_linker_hostname }}/
 </VirtualHost>
 

--- a/templates/sites-enabled/perun-profile.conf.j2
+++ b/templates/sites-enabled/perun-profile.conf.j2
@@ -10,6 +10,9 @@
 {% for alias in perun_ngui_profile_hostname_aliases %}
   ServerAlias {{ alias }}
 {% endfor %}
+
+  IncludeOptional /etc/perun/apache/acme.conf
+
   Redirect / https://{{ perun_ngui_profile_hostname }}/
 </VirtualHost>
 

--- a/templates/sites-enabled/perun-publications.conf.j2
+++ b/templates/sites-enabled/perun-publications.conf.j2
@@ -10,6 +10,9 @@
 {% for alias in perun_ngui_publications_hostname_aliases %}
   ServerAlias {{ alias }}
 {% endfor %}
+
+  IncludeOptional /etc/perun/apache/acme.conf
+
   Redirect / https://{{ perun_ngui_publications_hostname }}/
 </VirtualHost>
 

--- a/templates/sites-enabled/perun-pwdreset.conf.j2
+++ b/templates/sites-enabled/perun-pwdreset.conf.j2
@@ -10,6 +10,9 @@
 {% for alias in perun_ngui_pwdreset_hostname_aliases %}
   ServerAlias {{ alias }}
 {% endfor %}
+
+  IncludeOptional /etc/perun/apache/acme.conf
+
   Redirect / https://{{ perun_ngui_pwdreset_hostname }}/
 </VirtualHost>
 

--- a/templates/sites-enabled/perun.conf.j2
+++ b/templates/sites-enabled/perun.conf.j2
@@ -9,10 +9,10 @@ ServerName {{ perun_rpc_hostname }}
 {% for item in perun_rpc_hostname_aliases %}
   ServerAlias {{ item }}
 {% endfor %}
-  RewriteEngine On
-  RewriteCond %{HTTPS} !=on
-  RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 
+  IncludeOptional /etc/perun/apache/acme.conf
+
+  Redirect / https://{{ perun_rpc_hostname }}/
 </VirtualHost>
 
 # Support Federated and Kerberos authz on single instance


### PR DESCRIPTION
Added optional including of acme.conf to all virtual hosts on port 80. If the file does not exists, nothing happens. If it exists, it is expected to contain directives enabling ACME HTTP challenge for running Apache.