### PR TITLE
Fixed handling of /etc/hosts on the host

### DIFF
--- a/tasks/perun_apache.yml
+++ b/tasks/perun_apache.yml
@@ -464,6 +464,7 @@
         default_host_ip: ''
       register: perun_apache_container
 
+    # Note: we don't have to remove old entry in a separate task as deployment of apache container can't be "disabled" in vars
     - name: "put container IP into /etc/hosts"
       lineinfile:
         dest: /etc/hosts

--- a/tasks/perun_auditlogger.yml
+++ b/tasks/perun_auditlogger.yml
@@ -135,7 +135,7 @@
 - name: "remove old hostname"
   lineinfile:
     dest: /etc/hosts
-    regexp: 'perun_auditlogger'
+    regexp: 'perun-auditlogger'
     state: absent
 
 - name: "put container IP into /etc/hosts"

--- a/tasks/perun_engine.yml
+++ b/tasks/perun_engine.yml
@@ -406,7 +406,7 @@
 - name: "remove old hostname"
   lineinfile:
     dest: /etc/hosts
-    regexp: 'perun_engine'
+    regexp: 'perun-engine'
     state: absent
 
 - name: "put container IP into /etc/hosts"

--- a/tasks/perun_ldapc.yml
+++ b/tasks/perun_ldapc.yml
@@ -131,7 +131,7 @@
 - name: "remove old hostname"
   lineinfile:
     dest: /etc/hosts
-    regexp: 'perun_ldapc'
+    regexp: 'perun-ldapc'
     state: absent
 
 - name: "put container IP into /etc/hosts"

--- a/tasks/perun_rpc.yml
+++ b/tasks/perun_rpc.yml
@@ -283,12 +283,7 @@
       '*': strict
   register: perun_rpc_container
 
-- name: "remove old hostname"
-  lineinfile:
-    path: /etc/hosts
-    regexp: 'perun_rpc'
-    state: absent
-
+# Note: we don't have to remove old entry in a separate task as deployment of rpc container can't be "disabled" in vars
 - name: "put container IP into /etc/hosts"
   lineinfile:
     path: /etc/hosts


### PR DESCRIPTION
- We must clean correct hostname for each container from /etc/hosts on the host machine before adding a new one on container redeployment (we used to put "perun-rpc", but cleaned "perun_rpc").