### PR TITLE
Added support for third API domain

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -573,6 +573,13 @@ perun_api_alternative_hostname_aliases: []
 perun_apache_oauth_alternative_introspection_url: https://other.oidc.provider/oidc/introspection
 perun_apache_oauth_alternative_client_id: "yyyyyyyyy-yyyyyyyyy-yyyyyyyyy-yyyyyyyy"
 perun_apache_oauth_alternative_client_secret: "YYYYYYYYYYYYYYYYY"
+# third API with other OIDC
+perun_api_alternative2_enabled: no
+perun_api_alternative2_hostname: perun-api-third.example.org
+perun_api_alternative2_hostname_aliases: []
+perun_apache_oauth_alternative2_introspection_url: https://other2.oidc.provider/oidc/introspection
+perun_apache_oauth_alternative2_client_id: "yyyyyyyyy-yyyyyyyyy-yyyyyyyyy-yyyyyyyy"
+perun_apache_oauth_alternative2_client_secret: "YYYYYYYYYYYYYYYYY"
 
 # virtual host for CERT API (if enabled, /cert/ endpoint will no longer be available on default host)
 perun_api_cert_enabled: no
@@ -858,6 +865,10 @@ other_certs:
   - cond: perun_api_alternative_enabled
     hostname: perun_api_alternative_hostname
     aliases: perun_api_alternative_hostname_aliases
+
+  - cond: perun_api_alternative2_enabled
+    hostname: perun_api_alternative2_hostname
+    aliases: perun_api_alternative2_hostname_aliases
 
   - cond: perun_api_cert_enabled
     hostname: perun_api_cert_hostname

--- a/tasks/perun_apache.yml
+++ b/tasks/perun_apache.yml
@@ -219,6 +219,22 @@
     perun_apache_oauth_client_secret: "{{ perun_apache_oauth_alternative_client_secret }}"
   notify: "restart perun_apache"
 
+- name: "create /etc/perun/apache/sites-enabled/perun-api-alt2.conf"
+  when: perun_api_alternative2_enabled
+  template:
+    src: sites-enabled/perun-api.conf.j2
+    dest: /etc/perun/apache/sites-enabled/perun-api-alt2.conf
+    owner: root
+    group: root
+    mode: '0400'
+  vars:
+    perun_api_hostname: "{{ perun_api_alternative2_hostname }}"
+    perun_api_hostname_aliases: "{{ perun_api_alternative2_hostname_aliases }}"
+    perun_apache_oauth_introspection_url: "{{ perun_apache_oauth_alternative2_introspection_url }}"
+    perun_apache_oauth_client_id: "{{ perun_apache_oauth_alternative2_client_id }}"
+    perun_apache_oauth_client_secret: "{{ perun_apache_oauth_alternative2_client_secret }}"
+  notify: "restart perun_apache"
+
 - name: "create /etc/perun/apache/sites-enabled/perun-api-cert.conf"
   when: perun_api_cert_enabled
   template:


### PR DESCRIPTION
- To support more than 2 brandings with a different proxy we added option to define third api domain with a different oidc config. It is disabled by default.
- Properties are similar as for the first alternative api:
   - perun_api_alternative2_enabled
   - perun_api_alternative2_hostname
   - perun_api_alternative2_hostname_aliases
   - perun_apache_oauth_alternative2_introspection_url
   - perun_apache_oauth_alternative2_client_id
   - perun_apache_oauth_alternative2_client_secret