### PR TITLE
Support autoconfiguration for external python-cli scripts

### DIFF
--- a/templates/perun-cli-python-env.j2
+++ b/templates/perun-cli-python-env.j2
@@ -7,6 +7,8 @@
 PERUN_CLI_PYTHON_USER=perun
 PERUN_CLI_PYTHON_PASSWORD={{ perun_apache_basicAuth_user_perun_password }}
 PERUN_CLI_PYTHON_AUTH_TYPE=basic
+# Export path to default instances file so that external scripts can use our CLI and see it for autoconfiguration
+PERUN_CLI_PYTHON_INSTANCES_PATH="/opt/perun-cli/instances.json"
 
 # inherit these variables from the calling environment
 LOGNAME


### PR DESCRIPTION
- Newer version of python cli should support simple autoconfiguration for external scripts. Due to deployment changes these scripts couldn't see config of default instance used in autoconfiguration process.
- We now explicitly export path to the instances.json file present in the container deployed on each instance, hence external cron scrips can simply call "perun.rpc.setup_for_custom_scripts()" and then use our cli with their own perun instance.
- It has no impact on standard interactive python cli usage.